### PR TITLE
Implement opencode provider

### DIFF
--- a/.agents/skills/skill-creator/LICENSE.txt
+++ b/.agents/skills/skill-creator/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Anthropic, PBC.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.agents/skills/skill-creator/SKILL.md
+++ b/.agents/skills/skill-creator/SKILL.md
@@ -1,0 +1,485 @@
+---
+name: skill-creator
+description: Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy.
+---
+
+# Skill Creator
+
+A skill for creating new skills and iteratively improving them.
+
+At a high level, the process of creating a skill goes like this:
+
+- Decide what you want the skill to do and roughly how it should do it
+- Write a draft of the skill
+- Create a few test prompts and run claude-with-access-to-the-skill on them
+- Help the user evaluate the results both qualitatively and quantitatively
+  - While the runs happen in the background, draft some quantitative evals if there aren't any (if there are some, you can either use as is or modify if you feel something needs to change about them). Then explain them to the user (or if they already existed, explain the ones that already exist)
+  - Use the `eval-viewer/generate_review.py` script to show the user the results for them to look at, and also let them look at the quantitative metrics
+- Rewrite the skill based on feedback from the user's evaluation of the results (and also if there are any glaring flaws that become apparent from the quantitative benchmarks)
+- Repeat until you're satisfied
+- Expand the test set and try again at larger scale
+
+Your job when using this skill is to figure out where the user is in this process and then jump in and help them progress through these stages. So for instance, maybe they're like "I want to make a skill for X". You can help narrow down what they mean, write a draft, write the test cases, figure out how they want to evaluate, run all the prompts, and repeat.
+
+On the other hand, maybe they already have a draft of the skill. In this case you can go straight to the eval/iterate part of the loop.
+
+Of course, you should always be flexible and if the user is like "I don't need to run a bunch of evaluations, just vibe with me", you can do that instead.
+
+Then after the skill is done (but again, the order is flexible), you can also run the skill description improver, which we have a whole separate script for, to optimize the triggering of the skill.
+
+Cool? Cool.
+
+## Communicating with the user
+
+The skill creator is liable to be used by people across a wide range of familiarity with coding jargon. If you haven't heard (and how could you, it's only very recently that it started), there's a trend now where the power of Claude is inspiring plumbers to open up their terminals, parents and grandparents to google "how to install npm". On the other hand, the bulk of users are probably fairly computer-literate.
+
+So please pay attention to context cues to understand how to phrase your communication! In the default case, just to give you some idea:
+
+- "evaluation" and "benchmark" are borderline, but OK
+- for "JSON" and "assertion" you want to see serious cues from the user that they know what those things are before using them without explaining them
+
+It's OK to briefly explain terms if you're in doubt, and feel free to clarify terms with a short definition if you're unsure if the user will get it.
+
+---
+
+## Creating a skill
+
+### Capture Intent
+
+Start by understanding the user's intent. The current conversation might already contain a workflow the user wants to capture (e.g., they say "turn this into a skill"). If so, extract answers from the conversation history first — the tools used, the sequence of steps, corrections the user made, input/output formats observed. The user may need to fill the gaps, and should confirm before proceeding to the next step.
+
+1. What should this skill enable Claude to do?
+2. When should this skill trigger? (what user phrases/contexts)
+3. What's the expected output format?
+4. Should we set up test cases to verify the skill works? Skills with objectively verifiable outputs (file transforms, data extraction, code generation, fixed workflow steps) benefit from test cases. Skills with subjective outputs (writing style, art) often don't need them. Suggest the appropriate default based on the skill type, but let the user decide.
+
+### Interview and Research
+
+Proactively ask questions about edge cases, input/output formats, example files, success criteria, and dependencies. Wait to write test prompts until you've got this part ironed out.
+
+Check available MCPs - if useful for research (searching docs, finding similar skills, looking up best practices), research in parallel via subagents if available, otherwise inline. Come prepared with context to reduce burden on the user.
+
+### Write the SKILL.md
+
+Based on the user interview, fill in these components:
+
+- **name**: Skill identifier
+- **description**: When to trigger, what it does. This is the primary triggering mechanism - include both what the skill does AND specific contexts for when to use it. All "when to use" info goes here, not in the body. Note: currently Claude has a tendency to "undertrigger" skills -- to not use them when they'd be useful. To combat this, please make the skill descriptions a little bit "pushy". So for instance, instead of "How to build a simple fast dashboard to display internal Anthropic data.", you might write "How to build a simple fast dashboard to display internal Anthropic data. Make sure to use this skill whenever the user mentions dashboards, data visualization, internal metrics, or wants to display any kind of company data, even if they don't explicitly ask for a 'dashboard.'"
+- **compatibility**: Required tools, dependencies (optional, rarely needed)
+- **the rest of the skill :)**
+
+### Skill Writing Guide
+
+#### Anatomy of a Skill
+
+```
+skill-name/
+├── SKILL.md (required)
+│   ├── YAML frontmatter (name, description required)
+│   └── Markdown instructions
+└── Bundled Resources (optional)
+    ├── scripts/    - Executable code for deterministic/repetitive tasks
+    ├── references/ - Docs loaded into context as needed
+    └── assets/     - Files used in output (templates, icons, fonts)
+```
+
+#### Progressive Disclosure
+
+Skills use a three-level loading system:
+1. **Metadata** (name + description) - Always in context (~100 words)
+2. **SKILL.md body** - In context whenever skill triggers (<500 lines ideal)
+3. **Bundled resources** - As needed (unlimited, scripts can execute without loading)
+
+These word counts are approximate and you can feel free to go longer if needed.
+
+**Key patterns:**
+- Keep SKILL.md under 500 lines; if you're approaching this limit, add an additional layer of hierarchy along with clear pointers about where the model using the skill should go next to follow up.
+- Reference files clearly from SKILL.md with guidance on when to read them
+- For large reference files (>300 lines), include a table of contents
+
+**Domain organization**: When a skill supports multiple domains/frameworks, organize by variant:
+```
+cloud-deploy/
+├── SKILL.md (workflow + selection)
+└── references/
+    ├── aws.md
+    ├── gcp.md
+    └── azure.md
+```
+Claude reads only the relevant reference file.
+
+#### Principle of Lack of Surprise
+
+This goes without saying, but skills must not contain malware, exploit code, or any content that could compromise system security. A skill's contents should not surprise the user in their intent if described. Don't go along with requests to create misleading skills or skills designed to facilitate unauthorized access, data exfiltration, or other malicious activities. Things like a "roleplay as an XYZ" are OK though.
+
+#### Writing Patterns
+
+Prefer using the imperative form in instructions.
+
+**Defining output formats** - You can do it like this:
+```markdown
+## Report structure
+ALWAYS use this exact template:
+# [Title]
+## Executive summary
+## Key findings
+## Recommendations
+```
+
+**Examples pattern** - It's useful to include examples. You can format them like this (but if "Input" and "Output" are in the examples you might want to deviate a little):
+```markdown
+## Commit message format
+**Example 1:**
+Input: Added user authentication with JWT tokens
+Output: feat(auth): implement JWT-based authentication
+```
+
+### Writing Style
+
+Try to explain to the model why things are important in lieu of heavy-handed musty MUSTs. Use theory of mind and try to make the skill general and not super-narrow to specific examples. Start by writing a draft and then look at it with fresh eyes and improve it.
+
+### Test Cases
+
+After writing the skill draft, come up with 2-3 realistic test prompts — the kind of thing a real user would actually say. Share them with the user: [you don't have to use this exact language] "Here are a few test cases I'd like to try. Do these look right, or do you want to add more?" Then run them.
+
+Save test cases to `evals/evals.json`. Don't write assertions yet — just the prompts. You'll draft assertions in the next step while the runs are in progress.
+
+```json
+{
+  "skill_name": "example-skill",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "User's task prompt",
+      "expected_output": "Description of expected result",
+      "files": []
+    }
+  ]
+}
+```
+
+See `references/schemas.md` for the full schema (including the `assertions` field, which you'll add later).
+
+## Running and evaluating test cases
+
+This section is one continuous sequence — don't stop partway through. Do NOT use `/skill-test` or any other testing skill.
+
+Put results in `<skill-name>-workspace/` as a sibling to the skill directory. Within the workspace, organize results by iteration (`iteration-1/`, `iteration-2/`, etc.) and within that, each test case gets a directory (`eval-0/`, `eval-1/`, etc.). Don't create all of this upfront — just create directories as you go.
+
+### Step 1: Spawn all runs (with-skill AND baseline) in the same turn
+
+For each test case, spawn two subagents in the same turn — one with the skill, one without. This is important: don't spawn the with-skill runs first and then come back for baselines later. Launch everything at once so it all finishes around the same time.
+
+**With-skill run:**
+
+```
+Execute this task:
+- Skill path: <path-to-skill>
+- Task: <eval prompt>
+- Input files: <eval files if any, or "none">
+- Save outputs to: <workspace>/iteration-<N>/eval-<ID>/with_skill/outputs/
+- Outputs to save: <what the user cares about — e.g., "the .docx file", "the final CSV">
+```
+
+**Baseline run** (same prompt, but the baseline depends on context):
+- **Creating a new skill**: no skill at all. Same prompt, no skill path, save to `without_skill/outputs/`.
+- **Improving an existing skill**: the old version. Before editing, snapshot the skill (`cp -r <skill-path> <workspace>/skill-snapshot/`), then point the baseline subagent at the snapshot. Save to `old_skill/outputs/`.
+
+Write an `eval_metadata.json` for each test case (assertions can be empty for now). Give each eval a descriptive name based on what it's testing — not just "eval-0". Use this name for the directory too. If this iteration uses new or modified eval prompts, create these files for each new eval directory — don't assume they carry over from previous iterations.
+
+```json
+{
+  "eval_id": 0,
+  "eval_name": "descriptive-name-here",
+  "prompt": "The user's task prompt",
+  "assertions": []
+}
+```
+
+### Step 2: While runs are in progress, draft assertions
+
+Don't just wait for the runs to finish — you can use this time productively. Draft quantitative assertions for each test case and explain them to the user. If assertions already exist in `evals/evals.json`, review them and explain what they check.
+
+Good assertions are objectively verifiable and have descriptive names — they should read clearly in the benchmark viewer so someone glancing at the results immediately understands what each one checks. Subjective skills (writing style, design quality) are better evaluated qualitatively — don't force assertions onto things that need human judgment.
+
+Update the `eval_metadata.json` files and `evals/evals.json` with the assertions once drafted. Also explain to the user what they'll see in the viewer — both the qualitative outputs and the quantitative benchmark.
+
+### Step 3: As runs complete, capture timing data
+
+When each subagent task completes, you receive a notification containing `total_tokens` and `duration_ms`. Save this data immediately to `timing.json` in the run directory:
+
+```json
+{
+  "total_tokens": 84852,
+  "duration_ms": 23332,
+  "total_duration_seconds": 23.3
+}
+```
+
+This is the only opportunity to capture this data — it comes through the task notification and isn't persisted elsewhere. Process each notification as it arrives rather than trying to batch them.
+
+### Step 4: Grade, aggregate, and launch the viewer
+
+Once all runs are done:
+
+1. **Grade each run** — spawn a grader subagent (or grade inline) that reads `agents/grader.md` and evaluates each assertion against the outputs. Save results to `grading.json` in each run directory. The grading.json expectations array must use the fields `text`, `passed`, and `evidence` (not `name`/`met`/`details` or other variants) — the viewer depends on these exact field names. For assertions that can be checked programmatically, write and run a script rather than eyeballing it — scripts are faster, more reliable, and can be reused across iterations.
+
+2. **Aggregate into benchmark** — run the aggregation script from the skill-creator directory:
+   ```bash
+   python -m scripts.aggregate_benchmark <workspace>/iteration-N --skill-name <name>
+   ```
+   This produces `benchmark.json` and `benchmark.md` with pass_rate, time, and tokens for each configuration, with mean ± stddev and the delta. If generating benchmark.json manually, see `references/schemas.md` for the exact schema the viewer expects.
+Put each with_skill version before its baseline counterpart.
+
+3. **Do an analyst pass** — read the benchmark data and surface patterns the aggregate stats might hide. See `agents/analyzer.md` (the "Analyzing Benchmark Results" section) for what to look for — things like assertions that always pass regardless of skill (non-discriminating), high-variance evals (possibly flaky), and time/token tradeoffs.
+
+4. **Launch the viewer** with both qualitative outputs and quantitative data:
+   ```bash
+   nohup python <skill-creator-path>/eval-viewer/generate_review.py \
+     <workspace>/iteration-N \
+     --skill-name "my-skill" \
+     --benchmark <workspace>/iteration-N/benchmark.json \
+     > /dev/null 2>&1 &
+   VIEWER_PID=$!
+   ```
+   For iteration 2+, also pass `--previous-workspace <workspace>/iteration-<N-1>`.
+
+   **Cowork / headless environments:** If `webbrowser.open()` is not available or the environment has no display, use `--static <output_path>` to write a standalone HTML file instead of starting a server. Feedback will be downloaded as a `feedback.json` file when the user clicks "Submit All Reviews". After download, copy `feedback.json` into the workspace directory for the next iteration to pick up.
+
+Note: please use generate_review.py to create the viewer; there's no need to write custom HTML.
+
+5. **Tell the user** something like: "I've opened the results in your browser. There are two tabs — 'Outputs' lets you click through each test case and leave feedback, 'Benchmark' shows the quantitative comparison. When you're done, come back here and let me know."
+
+### What the user sees in the viewer
+
+The "Outputs" tab shows one test case at a time:
+- **Prompt**: the task that was given
+- **Output**: the files the skill produced, rendered inline where possible
+- **Previous Output** (iteration 2+): collapsed section showing last iteration's output
+- **Formal Grades** (if grading was run): collapsed section showing assertion pass/fail
+- **Feedback**: a textbox that auto-saves as they type
+- **Previous Feedback** (iteration 2+): their comments from last time, shown below the textbox
+
+The "Benchmark" tab shows the stats summary: pass rates, timing, and token usage for each configuration, with per-eval breakdowns and analyst observations.
+
+Navigation is via prev/next buttons or arrow keys. When done, they click "Submit All Reviews" which saves all feedback to `feedback.json`.
+
+### Step 5: Read the feedback
+
+When the user tells you they're done, read `feedback.json`:
+
+```json
+{
+  "reviews": [
+    {"run_id": "eval-0-with_skill", "feedback": "the chart is missing axis labels", "timestamp": "..."},
+    {"run_id": "eval-1-with_skill", "feedback": "", "timestamp": "..."},
+    {"run_id": "eval-2-with_skill", "feedback": "perfect, love this", "timestamp": "..."}
+  ],
+  "status": "complete"
+}
+```
+
+Empty feedback means the user thought it was fine. Focus your improvements on the test cases where the user had specific complaints.
+
+Kill the viewer server when you're done with it:
+
+```bash
+kill $VIEWER_PID 2>/dev/null
+```
+
+---
+
+## Improving the skill
+
+This is the heart of the loop. You've run the test cases, the user has reviewed the results, and now you need to make the skill better based on their feedback.
+
+### How to think about improvements
+
+1. **Generalize from the feedback.** The big picture thing that's happening here is that we're trying to create skills that can be used a million times (maybe literally, maybe even more who knows) across many different prompts. Here you and the user are iterating on only a few examples over and over again because it helps move faster. The user knows these examples in and out and it's quick for them to assess new outputs. But if the skill you and the user are codeveloping works only for those examples, it's useless. Rather than put in fiddly overfitty changes, or oppressively constrictive MUSTs, if there's some stubborn issue, you might try branching out and using different metaphors, or recommending different patterns of working. It's relatively cheap to try and maybe you'll land on something great.
+
+2. **Keep the prompt lean.** Remove things that aren't pulling their weight. Make sure to read the transcripts, not just the final outputs — if it looks like the skill is making the model waste a bunch of time doing things that are unproductive, you can try getting rid of the parts of the skill that are making it do that and seeing what happens.
+
+3. **Explain the why.** Try hard to explain the **why** behind everything you're asking the model to do. Today's LLMs are *smart*. They have good theory of mind and when given a good harness can go beyond rote instructions and really make things happen. Even if the feedback from the user is terse or frustrated, try to actually understand the task and why the user is writing what they wrote, and what they actually wrote, and then transmit this understanding into the instructions. If you find yourself writing ALWAYS or NEVER in all caps, or using super rigid structures, that's a yellow flag — if possible, reframe and explain the reasoning so that the model understands why the thing you're asking for is important. That's a more humane, powerful, and effective approach.
+
+4. **Look for repeated work across test cases.** Read the transcripts from the test runs and notice if the subagents all independently wrote similar helper scripts or took the same multi-step approach to something. If all 3 test cases resulted in the subagent writing a `create_docx.py` or a `build_chart.py`, that's a strong signal the skill should bundle that script. Write it once, put it in `scripts/`, and tell the skill to use it. This saves every future invocation from reinventing the wheel.
+
+This task is pretty important (we are trying to create billions a year in economic value here!) and your thinking time is not the blocker; take your time and really mull things over. I'd suggest writing a draft revision and then looking at it anew and making improvements. Really do your best to get into the head of the user and understand what they want and need.
+
+### The iteration loop
+
+After improving the skill:
+
+1. Apply your improvements to the skill
+2. Rerun all test cases into a new `iteration-<N+1>/` directory, including baseline runs. If you're creating a new skill, the baseline is always `without_skill` (no skill) — that stays the same across iterations. If you're improving an existing skill, use your judgment on what makes sense as the baseline: the original version the user came in with, or the previous iteration.
+3. Launch the reviewer with `--previous-workspace` pointing at the previous iteration
+4. Wait for the user to review and tell you they're done
+5. Read the new feedback, improve again, repeat
+
+Keep going until:
+- The user says they're happy
+- The feedback is all empty (everything looks good)
+- You're not making meaningful progress
+
+---
+
+## Advanced: Blind comparison
+
+For situations where you want a more rigorous comparison between two versions of a skill (e.g., the user asks "is the new version actually better?"), there's a blind comparison system. Read `agents/comparator.md` and `agents/analyzer.md` for the details. The basic idea is: give two outputs to an independent agent without telling it which is which, and let it judge quality. Then analyze why the winner won.
+
+This is optional, requires subagents, and most users won't need it. The human review loop is usually sufficient.
+
+---
+
+## Description Optimization
+
+The description field in SKILL.md frontmatter is the primary mechanism that determines whether Claude invokes a skill. After creating or improving a skill, offer to optimize the description for better triggering accuracy.
+
+### Step 1: Generate trigger eval queries
+
+Create 20 eval queries — a mix of should-trigger and should-not-trigger. Save as JSON:
+
+```json
+[
+  {"query": "the user prompt", "should_trigger": true},
+  {"query": "another prompt", "should_trigger": false}
+]
+```
+
+The queries must be realistic and something a Claude Code or Claude.ai user would actually type. Not abstract requests, but requests that are concrete and specific and have a good amount of detail. For instance, file paths, personal context about the user's job or situation, column names and values, company names, URLs. A little bit of backstory. Some might be in lowercase or contain abbreviations or typos or casual speech. Use a mix of different lengths, and focus on edge cases rather than making them clear-cut (the user will get a chance to sign off on them).
+
+Bad: `"Format this data"`, `"Extract text from PDF"`, `"Create a chart"`
+
+Good: `"ok so my boss just sent me this xlsx file (its in my downloads, called something like 'Q4 sales final FINAL v2.xlsx') and she wants me to add a column that shows the profit margin as a percentage. The revenue is in column C and costs are in column D i think"`
+
+For the **should-trigger** queries (8-10), think about coverage. You want different phrasings of the same intent — some formal, some casual. Include cases where the user doesn't explicitly name the skill or file type but clearly needs it. Throw in some uncommon use cases and cases where this skill competes with another but should win.
+
+For the **should-not-trigger** queries (8-10), the most valuable ones are the near-misses — queries that share keywords or concepts with the skill but actually need something different. Think adjacent domains, ambiguous phrasing where a naive keyword match would trigger but shouldn't, and cases where the query touches on something the skill does but in a context where another tool is more appropriate.
+
+The key thing to avoid: don't make should-not-trigger queries obviously irrelevant. "Write a fibonacci function" as a negative test for a PDF skill is too easy — it doesn't test anything. The negative cases should be genuinely tricky.
+
+### Step 2: Review with user
+
+Present the eval set to the user for review using the HTML template:
+
+1. Read the template from `assets/eval_review.html`
+2. Replace the placeholders:
+   - `__EVAL_DATA_PLACEHOLDER__` → the JSON array of eval items (no quotes around it — it's a JS variable assignment)
+   - `__SKILL_NAME_PLACEHOLDER__` → the skill's name
+   - `__SKILL_DESCRIPTION_PLACEHOLDER__` → the skill's current description
+3. Write to a temp file (e.g., `/tmp/eval_review_<skill-name>.html`) and open it: `open /tmp/eval_review_<skill-name>.html`
+4. The user can edit queries, toggle should-trigger, add/remove entries, then click "Export Eval Set"
+5. The file downloads to `~/Downloads/eval_set.json` — check the Downloads folder for the most recent version in case there are multiple (e.g., `eval_set (1).json`)
+
+This step matters — bad eval queries lead to bad descriptions.
+
+### Step 3: Run the optimization loop
+
+Tell the user: "This will take some time — I'll run the optimization loop in the background and check on it periodically."
+
+Save the eval set to the workspace, then run in the background:
+
+```bash
+python -m scripts.run_loop \
+  --eval-set <path-to-trigger-eval.json> \
+  --skill-path <path-to-skill> \
+  --model <model-id-powering-this-session> \
+  --max-iterations 5 \
+  --verbose
+```
+
+Use the model ID from your system prompt (the one powering the current session) so the triggering test matches what the user actually experiences.
+
+While it runs, periodically tail the output to give the user updates on which iteration it's on and what the scores look like.
+
+This handles the full optimization loop automatically. It splits the eval set into 60% train and 40% held-out test, evaluates the current description (running each query 3 times to get a reliable trigger rate), then calls Claude to propose improvements based on what failed. It re-evaluates each new description on both train and test, iterating up to 5 times. When it's done, it opens an HTML report in the browser showing the results per iteration and returns JSON with `best_description` — selected by test score rather than train score to avoid overfitting.
+
+### How skill triggering works
+
+Understanding the triggering mechanism helps design better eval queries. Skills appear in Claude's `available_skills` list with their name + description, and Claude decides whether to consult a skill based on that description. The important thing to know is that Claude only consults skills for tasks it can't easily handle on its own — simple, one-step queries like "read this PDF" may not trigger a skill even if the description matches perfectly, because Claude can handle them directly with basic tools. Complex, multi-step, or specialized queries reliably trigger skills when the description matches.
+
+This means your eval queries should be substantive enough that Claude would actually benefit from consulting a skill. Simple queries like "read file X" are poor test cases — they won't trigger skills regardless of description quality.
+
+### Step 4: Apply the result
+
+Take `best_description` from the JSON output and update the skill's SKILL.md frontmatter. Show the user before/after and report the scores.
+
+---
+
+### Package and Present (only if `present_files` tool is available)
+
+Check whether you have access to the `present_files` tool. If you don't, skip this step. If you do, package the skill and present the .skill file to the user:
+
+```bash
+python -m scripts.package_skill <path/to/skill-folder>
+```
+
+After packaging, direct the user to the resulting `.skill` file path so they can install it.
+
+---
+
+## Claude.ai-specific instructions
+
+In Claude.ai, the core workflow is the same (draft → test → review → improve → repeat), but because Claude.ai doesn't have subagents, some mechanics change. Here's what to adapt:
+
+**Running test cases**: No subagents means no parallel execution. For each test case, read the skill's SKILL.md, then follow its instructions to accomplish the test prompt yourself. Do them one at a time. This is less rigorous than independent subagents (you wrote the skill and you're also running it, so you have full context), but it's a useful sanity check — and the human review step compensates. Skip the baseline runs — just use the skill to complete the task as requested.
+
+**Reviewing results**: If you can't open a browser (e.g., Claude.ai's VM has no display, or you're on a remote server), skip the browser reviewer entirely. Instead, present results directly in the conversation. For each test case, show the prompt and the output. If the output is a file the user needs to see (like a .docx or .xlsx), save it to the filesystem and tell them where it is so they can download and inspect it. Ask for feedback inline: "How does this look? Anything you'd change?"
+
+**Benchmarking**: Skip the quantitative benchmarking — it relies on baseline comparisons which aren't meaningful without subagents. Focus on qualitative feedback from the user.
+
+**The iteration loop**: Same as before — improve the skill, rerun the test cases, ask for feedback — just without the browser reviewer in the middle. You can still organize results into iteration directories on the filesystem if you have one.
+
+**Description optimization**: This section requires the `claude` CLI tool (specifically `claude -p`) which is only available in Claude Code. Skip it if you're on Claude.ai.
+
+**Blind comparison**: Requires subagents. Skip it.
+
+**Packaging**: The `package_skill.py` script works anywhere with Python and a filesystem. On Claude.ai, you can run it and the user can download the resulting `.skill` file.
+
+**Updating an existing skill**: The user might be asking you to update an existing skill, not create a new one. In this case:
+- **Preserve the original name.** Note the skill's directory name and `name` frontmatter field -- use them unchanged. E.g., if the installed skill is `research-helper`, output `research-helper.skill` (not `research-helper-v2`).
+- **Copy to a writeable location before editing.** The installed skill path may be read-only. Copy to `/tmp/skill-name/`, edit there, and package from the copy.
+- **If packaging manually, stage in `/tmp/` first**, then copy to the output directory -- direct writes may fail due to permissions.
+
+---
+
+## Cowork-Specific Instructions
+
+If you're in Cowork, the main things to know are:
+
+- You have subagents, so the main workflow (spawn test cases in parallel, run baselines, grade, etc.) all works. (However, if you run into severe problems with timeouts, it's OK to run the test prompts in series rather than parallel.)
+- You don't have a browser or display, so when generating the eval viewer, use `--static <output_path>` to write a standalone HTML file instead of starting a server. Then proffer a link that the user can click to open the HTML in their browser.
+- For whatever reason, the Cowork setup seems to disincline Claude from generating the eval viewer after running the tests, so just to reiterate: whether you're in Cowork or in Claude Code, after running tests, you should always generate the eval viewer for the human to look at examples before revising the skill yourself and trying to make corrections, using `generate_review.py` (not writing your own boutique html code). Sorry in advance but I'm gonna go all caps here: GENERATE THE EVAL VIEWER *BEFORE* evaluating inputs yourself. You want to get them in front of the human ASAP!
+- Feedback works differently: since there's no running server, the viewer's "Submit All Reviews" button will download `feedback.json` as a file. You can then read it from there (you may have to request access first).
+- Packaging works — `package_skill.py` just needs Python and a filesystem.
+- Description optimization (`run_loop.py` / `run_eval.py`) should work in Cowork just fine since it uses `claude -p` via subprocess, not a browser, but please save it until you've fully finished making the skill and the user agrees it's in good shape.
+- **Updating an existing skill**: The user might be asking you to update an existing skill, not create a new one. Follow the update guidance in the claude.ai section above.
+
+---
+
+## Reference files
+
+The agents/ directory contains instructions for specialized subagents. Read them when you need to spawn the relevant subagent.
+
+- `agents/grader.md` — How to evaluate assertions against outputs
+- `agents/comparator.md` — How to do blind A/B comparison between two outputs
+- `agents/analyzer.md` — How to analyze why one version beat another
+
+The references/ directory has additional documentation:
+- `references/schemas.md` — JSON structures for evals.json, grading.json, etc.
+
+---
+
+Repeating one more time the core loop here for emphasis:
+
+- Figure out what the skill is about
+- Draft or edit the skill
+- Run claude-with-access-to-the-skill on test prompts
+- With the user, evaluate the outputs:
+  - Create benchmark.json and run `eval-viewer/generate_review.py` to help the user review them
+  - Run quantitative evals
+- Repeat until you and the user are satisfied
+- Package the final skill and return it to the user.
+
+Please add steps to your TodoList, if you have such a thing, to make sure you don't forget. If you're in Cowork, please specifically put "Create evals JSON and run `eval-viewer/generate_review.py` so human can review test cases" in your TodoList to make sure it happens.
+
+Good luck!

--- a/.agents/skills/skill-creator/agents/analyzer.md
+++ b/.agents/skills/skill-creator/agents/analyzer.md
@@ -1,0 +1,274 @@
+# Post-hoc Analyzer Agent
+
+Analyze blind comparison results to understand WHY the winner won and generate improvement suggestions.
+
+## Role
+
+After the blind comparator determines a winner, the Post-hoc Analyzer "unblids" the results by examining the skills and transcripts. The goal is to extract actionable insights: what made the winner better, and how can the loser be improved?
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **winner**: "A" or "B" (from blind comparison)
+- **winner_skill_path**: Path to the skill that produced the winning output
+- **winner_transcript_path**: Path to the execution transcript for the winner
+- **loser_skill_path**: Path to the skill that produced the losing output
+- **loser_transcript_path**: Path to the execution transcript for the loser
+- **comparison_result_path**: Path to the blind comparator's output JSON
+- **output_path**: Where to save the analysis results
+
+## Process
+
+### Step 1: Read Comparison Result
+
+1. Read the blind comparator's output at comparison_result_path
+2. Note the winning side (A or B), the reasoning, and any scores
+3. Understand what the comparator valued in the winning output
+
+### Step 2: Read Both Skills
+
+1. Read the winner skill's SKILL.md and key referenced files
+2. Read the loser skill's SKILL.md and key referenced files
+3. Identify structural differences:
+   - Instructions clarity and specificity
+   - Script/tool usage patterns
+   - Example coverage
+   - Edge case handling
+
+### Step 3: Read Both Transcripts
+
+1. Read the winner's transcript
+2. Read the loser's transcript
+3. Compare execution patterns:
+   - How closely did each follow their skill's instructions?
+   - What tools were used differently?
+   - Where did the loser diverge from optimal behavior?
+   - Did either encounter errors or make recovery attempts?
+
+### Step 4: Analyze Instruction Following
+
+For each transcript, evaluate:
+- Did the agent follow the skill's explicit instructions?
+- Did the agent use the skill's provided tools/scripts?
+- Were there missed opportunities to leverage skill content?
+- Did the agent add unnecessary steps not in the skill?
+
+Score instruction following 1-10 and note specific issues.
+
+### Step 5: Identify Winner Strengths
+
+Determine what made the winner better:
+- Clearer instructions that led to better behavior?
+- Better scripts/tools that produced better output?
+- More comprehensive examples that guided edge cases?
+- Better error handling guidance?
+
+Be specific. Quote from skills/transcripts where relevant.
+
+### Step 6: Identify Loser Weaknesses
+
+Determine what held the loser back:
+- Ambiguous instructions that led to suboptimal choices?
+- Missing tools/scripts that forced workarounds?
+- Gaps in edge case coverage?
+- Poor error handling that caused failures?
+
+### Step 7: Generate Improvement Suggestions
+
+Based on the analysis, produce actionable suggestions for improving the loser skill:
+- Specific instruction changes to make
+- Tools/scripts to add or modify
+- Examples to include
+- Edge cases to address
+
+Prioritize by impact. Focus on changes that would have changed the outcome.
+
+### Step 8: Write Analysis Results
+
+Save structured analysis to `{output_path}`.
+
+## Output Format
+
+Write a JSON file with this structure:
+
+```json
+{
+  "comparison_summary": {
+    "winner": "A",
+    "winner_skill": "path/to/winner/skill",
+    "loser_skill": "path/to/loser/skill",
+    "comparator_reasoning": "Brief summary of why comparator chose winner"
+  },
+  "winner_strengths": [
+    "Clear step-by-step instructions for handling multi-page documents",
+    "Included validation script that caught formatting errors",
+    "Explicit guidance on fallback behavior when OCR fails"
+  ],
+  "loser_weaknesses": [
+    "Vague instruction 'process the document appropriately' led to inconsistent behavior",
+    "No script for validation, agent had to improvise and made errors",
+    "No guidance on OCR failure, agent gave up instead of trying alternatives"
+  ],
+  "instruction_following": {
+    "winner": {
+      "score": 9,
+      "issues": [
+        "Minor: skipped optional logging step"
+      ]
+    },
+    "loser": {
+      "score": 6,
+      "issues": [
+        "Did not use the skill's formatting template",
+        "Invented own approach instead of following step 3",
+        "Missed the 'always validate output' instruction"
+      ]
+    }
+  },
+  "improvement_suggestions": [
+    {
+      "priority": "high",
+      "category": "instructions",
+      "suggestion": "Replace 'process the document appropriately' with explicit steps: 1) Extract text, 2) Identify sections, 3) Format per template",
+      "expected_impact": "Would eliminate ambiguity that caused inconsistent behavior"
+    },
+    {
+      "priority": "high",
+      "category": "tools",
+      "suggestion": "Add validate_output.py script similar to winner skill's validation approach",
+      "expected_impact": "Would catch formatting errors before final output"
+    },
+    {
+      "priority": "medium",
+      "category": "error_handling",
+      "suggestion": "Add fallback instructions: 'If OCR fails, try: 1) different resolution, 2) image preprocessing, 3) manual extraction'",
+      "expected_impact": "Would prevent early failure on difficult documents"
+    }
+  ],
+  "transcript_insights": {
+    "winner_execution_pattern": "Read skill -> Followed 5-step process -> Used validation script -> Fixed 2 issues -> Produced output",
+    "loser_execution_pattern": "Read skill -> Unclear on approach -> Tried 3 different methods -> No validation -> Output had errors"
+  }
+}
+```
+
+## Guidelines
+
+- **Be specific**: Quote from skills and transcripts, don't just say "instructions were unclear"
+- **Be actionable**: Suggestions should be concrete changes, not vague advice
+- **Focus on skill improvements**: The goal is to improve the losing skill, not critique the agent
+- **Prioritize by impact**: Which changes would most likely have changed the outcome?
+- **Consider causation**: Did the skill weakness actually cause the worse output, or is it incidental?
+- **Stay objective**: Analyze what happened, don't editorialize
+- **Think about generalization**: Would this improvement help on other evals too?
+
+## Categories for Suggestions
+
+Use these categories to organize improvement suggestions:
+
+| Category | Description |
+|----------|-------------|
+| `instructions` | Changes to the skill's prose instructions |
+| `tools` | Scripts, templates, or utilities to add/modify |
+| `examples` | Example inputs/outputs to include |
+| `error_handling` | Guidance for handling failures |
+| `structure` | Reorganization of skill content |
+| `references` | External docs or resources to add |
+
+## Priority Levels
+
+- **high**: Would likely change the outcome of this comparison
+- **medium**: Would improve quality but may not change win/loss
+- **low**: Nice to have, marginal improvement
+
+---
+
+# Analyzing Benchmark Results
+
+When analyzing benchmark results, the analyzer's purpose is to **surface patterns and anomalies** across multiple runs, not suggest skill improvements.
+
+## Role
+
+Review all benchmark run results and generate freeform notes that help the user understand skill performance. Focus on patterns that wouldn't be visible from aggregate metrics alone.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **benchmark_data_path**: Path to the in-progress benchmark.json with all run results
+- **skill_path**: Path to the skill being benchmarked
+- **output_path**: Where to save the notes (as JSON array of strings)
+
+## Process
+
+### Step 1: Read Benchmark Data
+
+1. Read the benchmark.json containing all run results
+2. Note the configurations tested (with_skill, without_skill)
+3. Understand the run_summary aggregates already calculated
+
+### Step 2: Analyze Per-Assertion Patterns
+
+For each expectation across all runs:
+- Does it **always pass** in both configurations? (may not differentiate skill value)
+- Does it **always fail** in both configurations? (may be broken or beyond capability)
+- Does it **always pass with skill but fail without**? (skill clearly adds value here)
+- Does it **always fail with skill but pass without**? (skill may be hurting)
+- Is it **highly variable**? (flaky expectation or non-deterministic behavior)
+
+### Step 3: Analyze Cross-Eval Patterns
+
+Look for patterns across evals:
+- Are certain eval types consistently harder/easier?
+- Do some evals show high variance while others are stable?
+- Are there surprising results that contradict expectations?
+
+### Step 4: Analyze Metrics Patterns
+
+Look at time_seconds, tokens, tool_calls:
+- Does the skill significantly increase execution time?
+- Is there high variance in resource usage?
+- Are there outlier runs that skew the aggregates?
+
+### Step 5: Generate Notes
+
+Write freeform observations as a list of strings. Each note should:
+- State a specific observation
+- Be grounded in the data (not speculation)
+- Help the user understand something the aggregate metrics don't show
+
+Examples:
+- "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value"
+- "Eval 3 shows high variance (50% ± 40%) - run 2 had an unusual failure that may be flaky"
+- "Without-skill runs consistently fail on table extraction expectations (0% pass rate)"
+- "Skill adds 13s average execution time but improves pass rate by 50%"
+- "Token usage is 80% higher with skill, primarily due to script output parsing"
+- "All 3 without-skill runs for eval 1 produced empty output"
+
+### Step 6: Write Notes
+
+Save notes to `{output_path}` as a JSON array of strings:
+
+```json
+[
+  "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value",
+  "Eval 3 shows high variance (50% ± 40%) - run 2 had an unusual failure",
+  "Without-skill runs consistently fail on table extraction expectations",
+  "Skill adds 13s average execution time but improves pass rate by 50%"
+]
+```
+
+## Guidelines
+
+**DO:**
+- Report what you observe in the data
+- Be specific about which evals, expectations, or runs you're referring to
+- Note patterns that aggregate metrics would hide
+- Provide context that helps interpret the numbers
+
+**DO NOT:**
+- Suggest improvements to the skill (that's for the improvement step, not benchmarking)
+- Make subjective quality judgments ("the output was good/bad")
+- Speculate about causes without evidence
+- Repeat information already in the run_summary aggregates

--- a/.agents/skills/skill-creator/agents/comparator.md
+++ b/.agents/skills/skill-creator/agents/comparator.md
@@ -1,0 +1,202 @@
+# Blind Comparator Agent
+
+Compare two outputs WITHOUT knowing which skill produced them.
+
+## Role
+
+The Blind Comparator judges which output better accomplishes the eval task. You receive two outputs labeled A and B, but you do NOT know which skill produced which. This prevents bias toward a particular skill or approach.
+
+Your judgment is based purely on output quality and task completion.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **output_a_path**: Path to the first output file or directory
+- **output_b_path**: Path to the second output file or directory
+- **eval_prompt**: The original task/prompt that was executed
+- **expectations**: List of expectations to check (optional - may be empty)
+
+## Process
+
+### Step 1: Read Both Outputs
+
+1. Examine output A (file or directory)
+2. Examine output B (file or directory)
+3. Note the type, structure, and content of each
+4. If outputs are directories, examine all relevant files inside
+
+### Step 2: Understand the Task
+
+1. Read the eval_prompt carefully
+2. Identify what the task requires:
+   - What should be produced?
+   - What qualities matter (accuracy, completeness, format)?
+   - What would distinguish a good output from a poor one?
+
+### Step 3: Generate Evaluation Rubric
+
+Based on the task, generate a rubric with two dimensions:
+
+**Content Rubric** (what the output contains):
+| Criterion | 1 (Poor) | 3 (Acceptable) | 5 (Excellent) |
+|-----------|----------|----------------|---------------|
+| Correctness | Major errors | Minor errors | Fully correct |
+| Completeness | Missing key elements | Mostly complete | All elements present |
+| Accuracy | Significant inaccuracies | Minor inaccuracies | Accurate throughout |
+
+**Structure Rubric** (how the output is organized):
+| Criterion | 1 (Poor) | 3 (Acceptable) | 5 (Excellent) |
+|-----------|----------|----------------|---------------|
+| Organization | Disorganized | Reasonably organized | Clear, logical structure |
+| Formatting | Inconsistent/broken | Mostly consistent | Professional, polished |
+| Usability | Difficult to use | Usable with effort | Easy to use |
+
+Adapt criteria to the specific task. For example:
+- PDF form → "Field alignment", "Text readability", "Data placement"
+- Document → "Section structure", "Heading hierarchy", "Paragraph flow"
+- Data output → "Schema correctness", "Data types", "Completeness"
+
+### Step 4: Evaluate Each Output Against the Rubric
+
+For each output (A and B):
+
+1. **Score each criterion** on the rubric (1-5 scale)
+2. **Calculate dimension totals**: Content score, Structure score
+3. **Calculate overall score**: Average of dimension scores, scaled to 1-10
+
+### Step 5: Check Assertions (if provided)
+
+If expectations are provided:
+
+1. Check each expectation against output A
+2. Check each expectation against output B
+3. Count pass rates for each output
+4. Use expectation scores as secondary evidence (not the primary decision factor)
+
+### Step 6: Determine the Winner
+
+Compare A and B based on (in priority order):
+
+1. **Primary**: Overall rubric score (content + structure)
+2. **Secondary**: Assertion pass rates (if applicable)
+3. **Tiebreaker**: If truly equal, declare a TIE
+
+Be decisive - ties should be rare. One output is usually better, even if marginally.
+
+### Step 7: Write Comparison Results
+
+Save results to a JSON file at the path specified (or `comparison.json` if not specified).
+
+## Output Format
+
+Write a JSON file with this structure:
+
+```json
+{
+  "winner": "A",
+  "reasoning": "Output A provides a complete solution with proper formatting and all required fields. Output B is missing the date field and has formatting inconsistencies.",
+  "rubric": {
+    "A": {
+      "content": {
+        "correctness": 5,
+        "completeness": 5,
+        "accuracy": 4
+      },
+      "structure": {
+        "organization": 4,
+        "formatting": 5,
+        "usability": 4
+      },
+      "content_score": 4.7,
+      "structure_score": 4.3,
+      "overall_score": 9.0
+    },
+    "B": {
+      "content": {
+        "correctness": 3,
+        "completeness": 2,
+        "accuracy": 3
+      },
+      "structure": {
+        "organization": 3,
+        "formatting": 2,
+        "usability": 3
+      },
+      "content_score": 2.7,
+      "structure_score": 2.7,
+      "overall_score": 5.4
+    }
+  },
+  "output_quality": {
+    "A": {
+      "score": 9,
+      "strengths": ["Complete solution", "Well-formatted", "All fields present"],
+      "weaknesses": ["Minor style inconsistency in header"]
+    },
+    "B": {
+      "score": 5,
+      "strengths": ["Readable output", "Correct basic structure"],
+      "weaknesses": ["Missing date field", "Formatting inconsistencies", "Partial data extraction"]
+    }
+  },
+  "expectation_results": {
+    "A": {
+      "passed": 4,
+      "total": 5,
+      "pass_rate": 0.80,
+      "details": [
+        {"text": "Output includes name", "passed": true},
+        {"text": "Output includes date", "passed": true},
+        {"text": "Format is PDF", "passed": true},
+        {"text": "Contains signature", "passed": false},
+        {"text": "Readable text", "passed": true}
+      ]
+    },
+    "B": {
+      "passed": 3,
+      "total": 5,
+      "pass_rate": 0.60,
+      "details": [
+        {"text": "Output includes name", "passed": true},
+        {"text": "Output includes date", "passed": false},
+        {"text": "Format is PDF", "passed": true},
+        {"text": "Contains signature", "passed": false},
+        {"text": "Readable text", "passed": true}
+      ]
+    }
+  }
+}
+```
+
+If no expectations were provided, omit the `expectation_results` field entirely.
+
+## Field Descriptions
+
+- **winner**: "A", "B", or "TIE"
+- **reasoning**: Clear explanation of why the winner was chosen (or why it's a tie)
+- **rubric**: Structured rubric evaluation for each output
+  - **content**: Scores for content criteria (correctness, completeness, accuracy)
+  - **structure**: Scores for structure criteria (organization, formatting, usability)
+  - **content_score**: Average of content criteria (1-5)
+  - **structure_score**: Average of structure criteria (1-5)
+  - **overall_score**: Combined score scaled to 1-10
+- **output_quality**: Summary quality assessment
+  - **score**: 1-10 rating (should match rubric overall_score)
+  - **strengths**: List of positive aspects
+  - **weaknesses**: List of issues or shortcomings
+- **expectation_results**: (Only if expectations provided)
+  - **passed**: Number of expectations that passed
+  - **total**: Total number of expectations
+  - **pass_rate**: Fraction passed (0.0 to 1.0)
+  - **details**: Individual expectation results
+
+## Guidelines
+
+- **Stay blind**: DO NOT try to infer which skill produced which output. Judge purely on output quality.
+- **Be specific**: Cite specific examples when explaining strengths and weaknesses.
+- **Be decisive**: Choose a winner unless outputs are genuinely equivalent.
+- **Output quality first**: Assertion scores are secondary to overall task completion.
+- **Be objective**: Don't favor outputs based on style preferences; focus on correctness and completeness.
+- **Explain your reasoning**: The reasoning field should make it clear why you chose the winner.
+- **Handle edge cases**: If both outputs fail, pick the one that fails less badly. If both are excellent, pick the one that's marginally better.

--- a/.agents/skills/skill-creator/agents/grader.md
+++ b/.agents/skills/skill-creator/agents/grader.md
@@ -1,0 +1,223 @@
+# Grader Agent
+
+Evaluate expectations against an execution transcript and outputs.
+
+## Role
+
+The Grader reviews a transcript and output files, then determines whether each expectation passes or fails. Provide clear evidence for each judgment.
+
+You have two jobs: grade the outputs, and critique the evals themselves. A passing grade on a weak assertion is worse than useless — it creates false confidence. When you notice an assertion that's trivially satisfied, or an important outcome that no assertion checks, say so.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **expectations**: List of expectations to evaluate (strings)
+- **transcript_path**: Path to the execution transcript (markdown file)
+- **outputs_dir**: Directory containing output files from execution
+
+## Process
+
+### Step 1: Read the Transcript
+
+1. Read the transcript file completely
+2. Note the eval prompt, execution steps, and final result
+3. Identify any issues or errors documented
+
+### Step 2: Examine Output Files
+
+1. List files in outputs_dir
+2. Read/examine each file relevant to the expectations. If outputs aren't plain text, use the inspection tools provided in your prompt — don't rely solely on what the transcript says the executor produced.
+3. Note contents, structure, and quality
+
+### Step 3: Evaluate Each Assertion
+
+For each expectation:
+
+1. **Search for evidence** in the transcript and outputs
+2. **Determine verdict**:
+   - **PASS**: Clear evidence the expectation is true AND the evidence reflects genuine task completion, not just surface-level compliance
+   - **FAIL**: No evidence, or evidence contradicts the expectation, or the evidence is superficial (e.g., correct filename but empty/wrong content)
+3. **Cite the evidence**: Quote the specific text or describe what you found
+
+### Step 4: Extract and Verify Claims
+
+Beyond the predefined expectations, extract implicit claims from the outputs and verify them:
+
+1. **Extract claims** from the transcript and outputs:
+   - Factual statements ("The form has 12 fields")
+   - Process claims ("Used pypdf to fill the form")
+   - Quality claims ("All fields were filled correctly")
+
+2. **Verify each claim**:
+   - **Factual claims**: Can be checked against the outputs or external sources
+   - **Process claims**: Can be verified from the transcript
+   - **Quality claims**: Evaluate whether the claim is justified
+
+3. **Flag unverifiable claims**: Note claims that cannot be verified with available information
+
+This catches issues that predefined expectations might miss.
+
+### Step 5: Read User Notes
+
+If `{outputs_dir}/user_notes.md` exists:
+1. Read it and note any uncertainties or issues flagged by the executor
+2. Include relevant concerns in the grading output
+3. These may reveal problems even when expectations pass
+
+### Step 6: Critique the Evals
+
+After grading, consider whether the evals themselves could be improved. Only surface suggestions when there's a clear gap.
+
+Good suggestions test meaningful outcomes — assertions that are hard to satisfy without actually doing the work correctly. Think about what makes an assertion *discriminating*: it passes when the skill genuinely succeeds and fails when it doesn't.
+
+Suggestions worth raising:
+- An assertion that passed but would also pass for a clearly wrong output (e.g., checking filename existence but not file content)
+- An important outcome you observed — good or bad — that no assertion covers at all
+- An assertion that can't actually be verified from the available outputs
+
+Keep the bar high. The goal is to flag things the eval author would say "good catch" about, not to nitpick every assertion.
+
+### Step 7: Write Grading Results
+
+Save results to `{outputs_dir}/../grading.json` (sibling to outputs_dir).
+
+## Grading Criteria
+
+**PASS when**:
+- The transcript or outputs clearly demonstrate the expectation is true
+- Specific evidence can be cited
+- The evidence reflects genuine substance, not just surface compliance (e.g., a file exists AND contains correct content, not just the right filename)
+
+**FAIL when**:
+- No evidence found for the expectation
+- Evidence contradicts the expectation
+- The expectation cannot be verified from available information
+- The evidence is superficial — the assertion is technically satisfied but the underlying task outcome is wrong or incomplete
+- The output appears to meet the assertion by coincidence rather than by actually doing the work
+
+**When uncertain**: The burden of proof to pass is on the expectation.
+
+### Step 8: Read Executor Metrics and Timing
+
+1. If `{outputs_dir}/metrics.json` exists, read it and include in grading output
+2. If `{outputs_dir}/../timing.json` exists, read it and include timing data
+
+## Output Format
+
+Write a JSON file with this structure:
+
+```json
+{
+  "expectations": [
+    {
+      "text": "The output includes the name 'John Smith'",
+      "passed": true,
+      "evidence": "Found in transcript Step 3: 'Extracted names: John Smith, Sarah Johnson'"
+    },
+    {
+      "text": "The spreadsheet has a SUM formula in cell B10",
+      "passed": false,
+      "evidence": "No spreadsheet was created. The output was a text file."
+    },
+    {
+      "text": "The assistant used the skill's OCR script",
+      "passed": true,
+      "evidence": "Transcript Step 2 shows: 'Tool: Bash - python ocr_script.py image.png'"
+    }
+  ],
+  "summary": {
+    "passed": 2,
+    "failed": 1,
+    "total": 3,
+    "pass_rate": 0.67
+  },
+  "execution_metrics": {
+    "tool_calls": {
+      "Read": 5,
+      "Write": 2,
+      "Bash": 8
+    },
+    "total_tool_calls": 15,
+    "total_steps": 6,
+    "errors_encountered": 0,
+    "output_chars": 12450,
+    "transcript_chars": 3200
+  },
+  "timing": {
+    "executor_duration_seconds": 165.0,
+    "grader_duration_seconds": 26.0,
+    "total_duration_seconds": 191.0
+  },
+  "claims": [
+    {
+      "claim": "The form has 12 fillable fields",
+      "type": "factual",
+      "verified": true,
+      "evidence": "Counted 12 fields in field_info.json"
+    },
+    {
+      "claim": "All required fields were populated",
+      "type": "quality",
+      "verified": false,
+      "evidence": "Reference section was left blank despite data being available"
+    }
+  ],
+  "user_notes_summary": {
+    "uncertainties": ["Used 2023 data, may be stale"],
+    "needs_review": [],
+    "workarounds": ["Fell back to text overlay for non-fillable fields"]
+  },
+  "eval_feedback": {
+    "suggestions": [
+      {
+        "assertion": "The output includes the name 'John Smith'",
+        "reason": "A hallucinated document that mentions the name would also pass — consider checking it appears as the primary contact with matching phone and email from the input"
+      },
+      {
+        "reason": "No assertion checks whether the extracted phone numbers match the input — I observed incorrect numbers in the output that went uncaught"
+      }
+    ],
+    "overall": "Assertions check presence but not correctness. Consider adding content verification."
+  }
+}
+```
+
+## Field Descriptions
+
+- **expectations**: Array of graded expectations
+  - **text**: The original expectation text
+  - **passed**: Boolean - true if expectation passes
+  - **evidence**: Specific quote or description supporting the verdict
+- **summary**: Aggregate statistics
+  - **passed**: Count of passed expectations
+  - **failed**: Count of failed expectations
+  - **total**: Total expectations evaluated
+  - **pass_rate**: Fraction passed (0.0 to 1.0)
+- **execution_metrics**: Copied from executor's metrics.json (if available)
+  - **output_chars**: Total character count of output files (proxy for tokens)
+  - **transcript_chars**: Character count of transcript
+- **timing**: Wall clock timing from timing.json (if available)
+  - **executor_duration_seconds**: Time spent in executor subagent
+  - **total_duration_seconds**: Total elapsed time for the run
+- **claims**: Extracted and verified claims from the output
+  - **claim**: The statement being verified
+  - **type**: "factual", "process", or "quality"
+  - **verified**: Boolean - whether the claim holds
+  - **evidence**: Supporting or contradicting evidence
+- **user_notes_summary**: Issues flagged by the executor
+  - **uncertainties**: Things the executor wasn't sure about
+  - **needs_review**: Items requiring human attention
+  - **workarounds**: Places where the skill didn't work as expected
+- **eval_feedback**: Improvement suggestions for the evals (only when warranted)
+  - **suggestions**: List of concrete suggestions, each with a `reason` and optionally an `assertion` it relates to
+  - **overall**: Brief assessment — can be "No suggestions, evals look solid" if nothing to flag
+
+## Guidelines
+
+- **Be objective**: Base verdicts on evidence, not assumptions
+- **Be specific**: Quote the exact text that supports your verdict
+- **Be thorough**: Check both transcript and output files
+- **Be consistent**: Apply the same standard to each expectation
+- **Explain failures**: Make it clear why evidence was insufficient
+- **No partial credit**: Each expectation is pass or fail, not partial

--- a/.agents/skills/skill-creator/assets/eval_review.html
+++ b/.agents/skills/skill-creator/assets/eval_review.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Eval Set Review - __SKILL_NAME_PLACEHOLDER__</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'Lora', Georgia, serif; background: #faf9f5; padding: 2rem; color: #141413; }
+    h1 { font-family: 'Poppins', sans-serif; margin-bottom: 0.5rem; font-size: 1.5rem; }
+    .description { color: #b0aea5; margin-bottom: 1.5rem; font-style: italic; max-width: 900px; }
+    .controls { margin-bottom: 1rem; display: flex; gap: 0.5rem; }
+    .btn { font-family: 'Poppins', sans-serif; padding: 0.5rem 1rem; border: none; border-radius: 6px; cursor: pointer; font-size: 0.875rem; font-weight: 500; }
+    .btn-add { background: #6a9bcc; color: white; }
+    .btn-add:hover { background: #5889b8; }
+    .btn-export { background: #d97757; color: white; }
+    .btn-export:hover { background: #c4613f; }
+    table { width: 100%; max-width: 1100px; border-collapse: collapse; background: white; border-radius: 6px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+    th { font-family: 'Poppins', sans-serif; background: #141413; color: #faf9f5; padding: 0.75rem 1rem; text-align: left; font-size: 0.875rem; }
+    td { padding: 0.75rem 1rem; border-bottom: 1px solid #e8e6dc; vertical-align: top; }
+    tr:nth-child(even) td { background: #faf9f5; }
+    tr:hover td { background: #f3f1ea; }
+    .section-header td { background: #e8e6dc; font-family: 'Poppins', sans-serif; font-weight: 500; font-size: 0.8rem; color: #141413; text-transform: uppercase; letter-spacing: 0.05em; }
+    .query-input { width: 100%; padding: 0.4rem; border: 1px solid #e8e6dc; border-radius: 4px; font-size: 0.875rem; font-family: 'Lora', Georgia, serif; resize: vertical; min-height: 60px; }
+    .query-input:focus { outline: none; border-color: #d97757; box-shadow: 0 0 0 2px rgba(217,119,87,0.15); }
+    .toggle { position: relative; display: inline-block; width: 44px; height: 24px; }
+    .toggle input { opacity: 0; width: 0; height: 0; }
+    .toggle .slider { position: absolute; inset: 0; background: #b0aea5; border-radius: 24px; cursor: pointer; transition: 0.2s; }
+    .toggle .slider::before { content: ""; position: absolute; width: 18px; height: 18px; left: 3px; bottom: 3px; background: white; border-radius: 50%; transition: 0.2s; }
+    .toggle input:checked + .slider { background: #d97757; }
+    .toggle input:checked + .slider::before { transform: translateX(20px); }
+    .btn-delete { background: #c44; color: white; padding: 0.3rem 0.6rem; border: none; border-radius: 4px; cursor: pointer; font-size: 0.75rem; font-family: 'Poppins', sans-serif; }
+    .btn-delete:hover { background: #a33; }
+    .summary { margin-top: 1rem; color: #b0aea5; font-size: 0.875rem; }
+  </style>
+</head>
+<body>
+  <h1>Eval Set Review: <span id="skill-name">__SKILL_NAME_PLACEHOLDER__</span></h1>
+  <p class="description">Current description: <span id="skill-desc">__SKILL_DESCRIPTION_PLACEHOLDER__</span></p>
+
+  <div class="controls">
+    <button class="btn btn-add" onclick="addRow()">+ Add Query</button>
+    <button class="btn btn-export" onclick="exportEvalSet()">Export Eval Set</button>
+  </div>
+
+  <table>
+    <thead>
+      <tr>
+        <th style="width:65%">Query</th>
+        <th style="width:18%">Should Trigger</th>
+        <th style="width:10%">Actions</th>
+      </tr>
+    </thead>
+    <tbody id="eval-body"></tbody>
+  </table>
+
+  <p class="summary" id="summary"></p>
+
+  <script>
+    const EVAL_DATA = __EVAL_DATA_PLACEHOLDER__;
+
+    let evalItems = [...EVAL_DATA];
+
+    function render() {
+      const tbody = document.getElementById('eval-body');
+      tbody.innerHTML = '';
+
+      // Sort: should-trigger first, then should-not-trigger
+      const sorted = evalItems
+        .map((item, origIdx) => ({ ...item, origIdx }))
+        .sort((a, b) => (b.should_trigger ? 1 : 0) - (a.should_trigger ? 1 : 0));
+
+      let lastGroup = null;
+      sorted.forEach(item => {
+        const group = item.should_trigger ? 'trigger' : 'no-trigger';
+        if (group !== lastGroup) {
+          const headerRow = document.createElement('tr');
+          headerRow.className = 'section-header';
+          headerRow.innerHTML = `<td colspan="3">${item.should_trigger ? 'Should Trigger' : 'Should NOT Trigger'}</td>`;
+          tbody.appendChild(headerRow);
+          lastGroup = group;
+        }
+
+        const idx = item.origIdx;
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td><textarea class="query-input" onchange="updateQuery(${idx}, this.value)">${escapeHtml(item.query)}</textarea></td>
+          <td>
+            <label class="toggle">
+              <input type="checkbox" ${item.should_trigger ? 'checked' : ''} onchange="updateTrigger(${idx}, this.checked)">
+              <span class="slider"></span>
+            </label>
+            <span style="margin-left:8px;font-size:0.8rem;color:#b0aea5">${item.should_trigger ? 'Yes' : 'No'}</span>
+          </td>
+          <td><button class="btn-delete" onclick="deleteRow(${idx})">Delete</button></td>
+        `;
+        tbody.appendChild(tr);
+      });
+      updateSummary();
+    }
+
+    function escapeHtml(text) {
+      const div = document.createElement('div');
+      div.textContent = text;
+      return div.innerHTML;
+    }
+
+    function updateQuery(idx, value) { evalItems[idx].query = value; updateSummary(); }
+    function updateTrigger(idx, value) { evalItems[idx].should_trigger = value; render(); }
+    function deleteRow(idx) { evalItems.splice(idx, 1); render(); }
+
+    function addRow() {
+      evalItems.push({ query: '', should_trigger: true });
+      render();
+      const inputs = document.querySelectorAll('.query-input');
+      inputs[inputs.length - 1].focus();
+    }
+
+    function updateSummary() {
+      const trigger = evalItems.filter(i => i.should_trigger).length;
+      const noTrigger = evalItems.filter(i => !i.should_trigger).length;
+      document.getElementById('summary').textContent =
+        `${evalItems.length} queries total: ${trigger} should trigger, ${noTrigger} should not trigger`;
+    }
+
+    function exportEvalSet() {
+      const valid = evalItems.filter(i => i.query.trim() !== '');
+      const data = valid.map(i => ({ query: i.query.trim(), should_trigger: i.should_trigger }));
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'eval_set.json';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    }
+
+    render();
+  </script>
+</body>
+</html>

--- a/.agents/skills/skill-creator/eval-viewer/generate_review.py
+++ b/.agents/skills/skill-creator/eval-viewer/generate_review.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+"""Generate and serve a review page for eval results.
+
+Reads the workspace directory, discovers runs (directories with outputs/),
+embeds all output data into a self-contained HTML page, and serves it via
+a tiny HTTP server. Feedback auto-saves to feedback.json in the workspace.
+
+Usage:
+    python generate_review.py <workspace-path> [--port PORT] [--skill-name NAME]
+    python generate_review.py <workspace-path> --previous-feedback /path/to/old/feedback.json
+
+No dependencies beyond the Python stdlib are required.
+"""
+
+import argparse
+import base64
+import json
+import mimetypes
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+import webbrowser
+from functools import partial
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from pathlib import Path
+
+# Files to exclude from output listings
+METADATA_FILES = {"transcript.md", "user_notes.md", "metrics.json"}
+
+# Extensions we render as inline text
+TEXT_EXTENSIONS = {
+    ".txt", ".md", ".json", ".csv", ".py", ".js", ".ts", ".tsx", ".jsx",
+    ".yaml", ".yml", ".xml", ".html", ".css", ".sh", ".rb", ".go", ".rs",
+    ".java", ".c", ".cpp", ".h", ".hpp", ".sql", ".r", ".toml",
+}
+
+# Extensions we render as inline images
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"}
+
+# MIME type overrides for common types
+MIME_OVERRIDES = {
+    ".svg": "image/svg+xml",
+    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+}
+
+
+def get_mime_type(path: Path) -> str:
+    ext = path.suffix.lower()
+    if ext in MIME_OVERRIDES:
+        return MIME_OVERRIDES[ext]
+    mime, _ = mimetypes.guess_type(str(path))
+    return mime or "application/octet-stream"
+
+
+def find_runs(workspace: Path) -> list[dict]:
+    """Recursively find directories that contain an outputs/ subdirectory."""
+    runs: list[dict] = []
+    _find_runs_recursive(workspace, workspace, runs)
+    runs.sort(key=lambda r: (r.get("eval_id", float("inf")), r["id"]))
+    return runs
+
+
+def _find_runs_recursive(root: Path, current: Path, runs: list[dict]) -> None:
+    if not current.is_dir():
+        return
+
+    outputs_dir = current / "outputs"
+    if outputs_dir.is_dir():
+        run = build_run(root, current)
+        if run:
+            runs.append(run)
+        return
+
+    skip = {"node_modules", ".git", "__pycache__", "skill", "inputs"}
+    for child in sorted(current.iterdir()):
+        if child.is_dir() and child.name not in skip:
+            _find_runs_recursive(root, child, runs)
+
+
+def build_run(root: Path, run_dir: Path) -> dict | None:
+    """Build a run dict with prompt, outputs, and grading data."""
+    prompt = ""
+    eval_id = None
+
+    # Try eval_metadata.json
+    for candidate in [run_dir / "eval_metadata.json", run_dir.parent / "eval_metadata.json"]:
+        if candidate.exists():
+            try:
+                metadata = json.loads(candidate.read_text())
+                prompt = metadata.get("prompt", "")
+                eval_id = metadata.get("eval_id")
+            except (json.JSONDecodeError, OSError):
+                pass
+            if prompt:
+                break
+
+    # Fall back to transcript.md
+    if not prompt:
+        for candidate in [run_dir / "transcript.md", run_dir / "outputs" / "transcript.md"]:
+            if candidate.exists():
+                try:
+                    text = candidate.read_text()
+                    match = re.search(r"## Eval Prompt\n\n([\s\S]*?)(?=\n##|$)", text)
+                    if match:
+                        prompt = match.group(1).strip()
+                except OSError:
+                    pass
+                if prompt:
+                    break
+
+    if not prompt:
+        prompt = "(No prompt found)"
+
+    run_id = str(run_dir.relative_to(root)).replace("/", "-").replace("\\", "-")
+
+    # Collect output files
+    outputs_dir = run_dir / "outputs"
+    output_files: list[dict] = []
+    if outputs_dir.is_dir():
+        for f in sorted(outputs_dir.iterdir()):
+            if f.is_file() and f.name not in METADATA_FILES:
+                output_files.append(embed_file(f))
+
+    # Load grading if present
+    grading = None
+    for candidate in [run_dir / "grading.json", run_dir.parent / "grading.json"]:
+        if candidate.exists():
+            try:
+                grading = json.loads(candidate.read_text())
+            except (json.JSONDecodeError, OSError):
+                pass
+            if grading:
+                break
+
+    return {
+        "id": run_id,
+        "prompt": prompt,
+        "eval_id": eval_id,
+        "outputs": output_files,
+        "grading": grading,
+    }
+
+
+def embed_file(path: Path) -> dict:
+    """Read a file and return an embedded representation."""
+    ext = path.suffix.lower()
+    mime = get_mime_type(path)
+
+    if ext in TEXT_EXTENSIONS:
+        try:
+            content = path.read_text(errors="replace")
+        except OSError:
+            content = "(Error reading file)"
+        return {
+            "name": path.name,
+            "type": "text",
+            "content": content,
+        }
+    elif ext in IMAGE_EXTENSIONS:
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "image",
+            "mime": mime,
+            "data_uri": f"data:{mime};base64,{b64}",
+        }
+    elif ext == ".pdf":
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "pdf",
+            "data_uri": f"data:{mime};base64,{b64}",
+        }
+    elif ext == ".xlsx":
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "xlsx",
+            "data_b64": b64,
+        }
+    else:
+        # Binary / unknown — base64 download link
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "binary",
+            "mime": mime,
+            "data_uri": f"data:{mime};base64,{b64}",
+        }
+
+
+def load_previous_iteration(workspace: Path) -> dict[str, dict]:
+    """Load previous iteration's feedback and outputs.
+
+    Returns a map of run_id -> {"feedback": str, "outputs": list[dict]}.
+    """
+    result: dict[str, dict] = {}
+
+    # Load feedback
+    feedback_map: dict[str, str] = {}
+    feedback_path = workspace / "feedback.json"
+    if feedback_path.exists():
+        try:
+            data = json.loads(feedback_path.read_text())
+            feedback_map = {
+                r["run_id"]: r["feedback"]
+                for r in data.get("reviews", [])
+                if r.get("feedback", "").strip()
+            }
+        except (json.JSONDecodeError, OSError, KeyError):
+            pass
+
+    # Load runs (to get outputs)
+    prev_runs = find_runs(workspace)
+    for run in prev_runs:
+        result[run["id"]] = {
+            "feedback": feedback_map.get(run["id"], ""),
+            "outputs": run.get("outputs", []),
+        }
+
+    # Also add feedback for run_ids that had feedback but no matching run
+    for run_id, fb in feedback_map.items():
+        if run_id not in result:
+            result[run_id] = {"feedback": fb, "outputs": []}
+
+    return result
+
+
+def generate_html(
+    runs: list[dict],
+    skill_name: str,
+    previous: dict[str, dict] | None = None,
+    benchmark: dict | None = None,
+) -> str:
+    """Generate the complete standalone HTML page with embedded data."""
+    template_path = Path(__file__).parent / "viewer.html"
+    template = template_path.read_text()
+
+    # Build previous_feedback and previous_outputs maps for the template
+    previous_feedback: dict[str, str] = {}
+    previous_outputs: dict[str, list[dict]] = {}
+    if previous:
+        for run_id, data in previous.items():
+            if data.get("feedback"):
+                previous_feedback[run_id] = data["feedback"]
+            if data.get("outputs"):
+                previous_outputs[run_id] = data["outputs"]
+
+    embedded = {
+        "skill_name": skill_name,
+        "runs": runs,
+        "previous_feedback": previous_feedback,
+        "previous_outputs": previous_outputs,
+    }
+    if benchmark:
+        embedded["benchmark"] = benchmark
+
+    data_json = json.dumps(embedded)
+
+    return template.replace("/*__EMBEDDED_DATA__*/", f"const EMBEDDED_DATA = {data_json};")
+
+
+# ---------------------------------------------------------------------------
+# HTTP server (stdlib only, zero dependencies)
+# ---------------------------------------------------------------------------
+
+def _kill_port(port: int) -> None:
+    """Kill any process listening on the given port."""
+    try:
+        result = subprocess.run(
+            ["lsof", "-ti", f":{port}"],
+            capture_output=True, text=True, timeout=5,
+        )
+        for pid_str in result.stdout.strip().split("\n"):
+            if pid_str.strip():
+                try:
+                    os.kill(int(pid_str.strip()), signal.SIGTERM)
+                except (ProcessLookupError, ValueError):
+                    pass
+        if result.stdout.strip():
+            time.sleep(0.5)
+    except subprocess.TimeoutExpired:
+        pass
+    except FileNotFoundError:
+        print("Note: lsof not found, cannot check if port is in use", file=sys.stderr)
+
+class ReviewHandler(BaseHTTPRequestHandler):
+    """Serves the review HTML and handles feedback saves.
+
+    Regenerates the HTML on each page load so that refreshing the browser
+    picks up new eval outputs without restarting the server.
+    """
+
+    def __init__(
+        self,
+        workspace: Path,
+        skill_name: str,
+        feedback_path: Path,
+        previous: dict[str, dict],
+        benchmark_path: Path | None,
+        *args,
+        **kwargs,
+    ):
+        self.workspace = workspace
+        self.skill_name = skill_name
+        self.feedback_path = feedback_path
+        self.previous = previous
+        self.benchmark_path = benchmark_path
+        super().__init__(*args, **kwargs)
+
+    def do_GET(self) -> None:
+        if self.path == "/" or self.path == "/index.html":
+            # Regenerate HTML on each request (re-scans workspace for new outputs)
+            runs = find_runs(self.workspace)
+            benchmark = None
+            if self.benchmark_path and self.benchmark_path.exists():
+                try:
+                    benchmark = json.loads(self.benchmark_path.read_text())
+                except (json.JSONDecodeError, OSError):
+                    pass
+            html = generate_html(runs, self.skill_name, self.previous, benchmark)
+            content = html.encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(content)))
+            self.end_headers()
+            self.wfile.write(content)
+        elif self.path == "/api/feedback":
+            data = b"{}"
+            if self.feedback_path.exists():
+                data = self.feedback_path.read_bytes()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+        else:
+            self.send_error(404)
+
+    def do_POST(self) -> None:
+        if self.path == "/api/feedback":
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length)
+            try:
+                data = json.loads(body)
+                if not isinstance(data, dict) or "reviews" not in data:
+                    raise ValueError("Expected JSON object with 'reviews' key")
+                self.feedback_path.write_text(json.dumps(data, indent=2) + "\n")
+                resp = b'{"ok":true}'
+                self.send_response(200)
+            except (json.JSONDecodeError, OSError, ValueError) as e:
+                resp = json.dumps({"error": str(e)}).encode()
+                self.send_response(500)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(resp)))
+            self.end_headers()
+            self.wfile.write(resp)
+        else:
+            self.send_error(404)
+
+    def log_message(self, format: str, *args: object) -> None:
+        # Suppress request logging to keep terminal clean
+        pass
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate and serve eval review")
+    parser.add_argument("workspace", type=Path, help="Path to workspace directory")
+    parser.add_argument("--port", "-p", type=int, default=3117, help="Server port (default: 3117)")
+    parser.add_argument("--skill-name", "-n", type=str, default=None, help="Skill name for header")
+    parser.add_argument(
+        "--previous-workspace", type=Path, default=None,
+        help="Path to previous iteration's workspace (shows old outputs and feedback as context)",
+    )
+    parser.add_argument(
+        "--benchmark", type=Path, default=None,
+        help="Path to benchmark.json to show in the Benchmark tab",
+    )
+    parser.add_argument(
+        "--static", "-s", type=Path, default=None,
+        help="Write standalone HTML to this path instead of starting a server",
+    )
+    args = parser.parse_args()
+
+    workspace = args.workspace.resolve()
+    if not workspace.is_dir():
+        print(f"Error: {workspace} is not a directory", file=sys.stderr)
+        sys.exit(1)
+
+    runs = find_runs(workspace)
+    if not runs:
+        print(f"No runs found in {workspace}", file=sys.stderr)
+        sys.exit(1)
+
+    skill_name = args.skill_name or workspace.name.replace("-workspace", "")
+    feedback_path = workspace / "feedback.json"
+
+    previous: dict[str, dict] = {}
+    if args.previous_workspace:
+        previous = load_previous_iteration(args.previous_workspace.resolve())
+
+    benchmark_path = args.benchmark.resolve() if args.benchmark else None
+    benchmark = None
+    if benchmark_path and benchmark_path.exists():
+        try:
+            benchmark = json.loads(benchmark_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    if args.static:
+        html = generate_html(runs, skill_name, previous, benchmark)
+        args.static.parent.mkdir(parents=True, exist_ok=True)
+        args.static.write_text(html)
+        print(f"\n  Static viewer written to: {args.static}\n")
+        sys.exit(0)
+
+    # Kill any existing process on the target port
+    port = args.port
+    _kill_port(port)
+    handler = partial(ReviewHandler, workspace, skill_name, feedback_path, previous, benchmark_path)
+    try:
+        server = HTTPServer(("127.0.0.1", port), handler)
+    except OSError:
+        # Port still in use after kill attempt — find a free one
+        server = HTTPServer(("127.0.0.1", 0), handler)
+        port = server.server_address[1]
+
+    url = f"http://localhost:{port}"
+    print(f"\n  Eval Viewer")
+    print(f"  ─────────────────────────────────")
+    print(f"  URL:       {url}")
+    print(f"  Workspace: {workspace}")
+    print(f"  Feedback:  {feedback_path}")
+    if previous:
+        print(f"  Previous:  {args.previous_workspace} ({len(previous)} runs)")
+    if benchmark_path:
+        print(f"  Benchmark: {benchmark_path}")
+    print(f"\n  Press Ctrl+C to stop.\n")
+
+    webbrowser.open(url)
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopped.")
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/skill-creator/eval-viewer/viewer.html
+++ b/.agents/skills/skill-creator/eval-viewer/viewer.html
@@ -1,0 +1,1325 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Eval Review</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">
+  <script src="https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js" integrity="sha384-EnyY0/GSHQGSxSgMwaIPzSESbqoOLSexfnSMN2AP+39Ckmn92stwABZynq1JyzdT" crossorigin="anonymous"></script>
+  <style>
+    :root {
+      --bg: #faf9f5;
+      --surface: #ffffff;
+      --border: #e8e6dc;
+      --text: #141413;
+      --text-muted: #b0aea5;
+      --accent: #d97757;
+      --accent-hover: #c4613f;
+      --green: #788c5d;
+      --green-bg: #eef2e8;
+      --red: #c44;
+      --red-bg: #fceaea;
+      --header-bg: #141413;
+      --header-text: #faf9f5;
+      --radius: 6px;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Lora', Georgia, serif;
+      background: var(--bg);
+      color: var(--text);
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* ---- Header ---- */
+    .header {
+      background: var(--header-bg);
+      color: var(--header-text);
+      padding: 1rem 2rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-shrink: 0;
+    }
+    .header h1 {
+      font-family: 'Poppins', sans-serif;
+      font-size: 1.25rem;
+      font-weight: 600;
+    }
+    .header .instructions {
+      font-size: 0.8rem;
+      opacity: 0.7;
+      margin-top: 0.25rem;
+    }
+    .header .progress {
+      font-size: 0.875rem;
+      opacity: 0.8;
+      text-align: right;
+    }
+
+    /* ---- Main content ---- */
+    .main {
+      flex: 1;
+      overflow-y: auto;
+      padding: 1.5rem 2rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1.25rem;
+    }
+
+    /* ---- Sections ---- */
+    .section {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      flex-shrink: 0;
+    }
+    .section-header {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.75rem 1rem;
+      font-size: 0.75rem;
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--text-muted);
+      border-bottom: 1px solid var(--border);
+      background: var(--bg);
+    }
+    .section-body {
+      padding: 1rem;
+    }
+
+    /* ---- Config badge ---- */
+    .config-badge {
+      display: inline-block;
+      padding: 0.2rem 0.625rem;
+      border-radius: 9999px;
+      font-family: 'Poppins', sans-serif;
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      margin-left: 0.75rem;
+      vertical-align: middle;
+    }
+    .config-badge.config-primary {
+      background: rgba(33, 150, 243, 0.12);
+      color: #1976d2;
+    }
+    .config-badge.config-baseline {
+      background: rgba(255, 193, 7, 0.15);
+      color: #f57f17;
+    }
+
+    /* ---- Prompt ---- */
+    .prompt-text {
+      white-space: pre-wrap;
+      font-size: 0.9375rem;
+      line-height: 1.6;
+    }
+
+    /* ---- Outputs ---- */
+    .output-file {
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+    }
+    .output-file + .output-file {
+      margin-top: 1rem;
+    }
+    .output-file-header {
+      padding: 0.5rem 0.75rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .output-file-header .dl-btn {
+      font-size: 0.7rem;
+      color: var(--accent);
+      text-decoration: none;
+      cursor: pointer;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      font-weight: 500;
+      opacity: 0.8;
+    }
+    .output-file-header .dl-btn:hover {
+      opacity: 1;
+      text-decoration: underline;
+    }
+    .output-file-content {
+      padding: 0.75rem;
+      overflow-x: auto;
+    }
+    .output-file-content pre {
+      font-size: 0.8125rem;
+      line-height: 1.5;
+      white-space: pre-wrap;
+      word-break: break-word;
+      font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+    }
+    .output-file-content img {
+      max-width: 100%;
+      height: auto;
+      border-radius: 4px;
+    }
+    .output-file-content iframe {
+      width: 100%;
+      height: 600px;
+      border: none;
+    }
+    .output-file-content table {
+      border-collapse: collapse;
+      font-size: 0.8125rem;
+      width: 100%;
+    }
+    .output-file-content table td,
+    .output-file-content table th {
+      border: 1px solid var(--border);
+      padding: 0.375rem 0.5rem;
+      text-align: left;
+    }
+    .output-file-content table th {
+      background: var(--bg);
+      font-weight: 600;
+    }
+    .output-file-content .download-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      color: var(--accent);
+      text-decoration: none;
+      font-size: 0.875rem;
+      cursor: pointer;
+    }
+    .output-file-content .download-link:hover {
+      background: var(--border);
+    }
+    .empty-state {
+      color: var(--text-muted);
+      font-style: italic;
+      padding: 2rem;
+      text-align: center;
+    }
+
+    /* ---- Feedback ---- */
+    .prev-feedback {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 0.625rem 0.75rem;
+      margin-top: 0.75rem;
+      font-size: 0.8125rem;
+      color: var(--text-muted);
+      line-height: 1.5;
+    }
+    .prev-feedback-label {
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      margin-bottom: 0.25rem;
+      color: var(--text-muted);
+    }
+    .feedback-textarea {
+      width: 100%;
+      min-height: 100px;
+      padding: 0.75rem;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      font-family: inherit;
+      font-size: 0.9375rem;
+      line-height: 1.5;
+      resize: vertical;
+      color: var(--text);
+    }
+    .feedback-textarea:focus {
+      outline: none;
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+    }
+    .feedback-status {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      margin-top: 0.5rem;
+      min-height: 1.1em;
+    }
+
+    /* ---- Grades (collapsible) ---- */
+    .grades-toggle {
+      display: flex;
+      align-items: center;
+      cursor: pointer;
+      user-select: none;
+    }
+    .grades-toggle:hover {
+      color: var(--accent);
+    }
+    .grades-toggle .arrow {
+      margin-right: 0.5rem;
+      transition: transform 0.15s;
+      font-size: 0.75rem;
+    }
+    .grades-toggle .arrow.open {
+      transform: rotate(90deg);
+    }
+    .grades-content {
+      display: none;
+      margin-top: 0.75rem;
+    }
+    .grades-content.open {
+      display: block;
+    }
+    .grades-summary {
+      font-size: 0.875rem;
+      margin-bottom: 0.75rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .grade-badge {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+    .grade-pass { background: var(--green-bg); color: var(--green); }
+    .grade-fail { background: var(--red-bg); color: var(--red); }
+    .assertion-list {
+      list-style: none;
+    }
+    .assertion-item {
+      padding: 0.625rem 0;
+      border-bottom: 1px solid var(--border);
+      font-size: 0.8125rem;
+    }
+    .assertion-item:last-child { border-bottom: none; }
+    .assertion-status {
+      font-weight: 600;
+      margin-right: 0.5rem;
+    }
+    .assertion-status.pass { color: var(--green); }
+    .assertion-status.fail { color: var(--red); }
+    .assertion-evidence {
+      color: var(--text-muted);
+      font-size: 0.75rem;
+      margin-top: 0.25rem;
+      padding-left: 1.5rem;
+    }
+
+    /* ---- View tabs ---- */
+    .view-tabs {
+      display: flex;
+      gap: 0;
+      padding: 0 2rem;
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+    .view-tab {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.625rem 1.25rem;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      cursor: pointer;
+      border: none;
+      background: none;
+      color: var(--text-muted);
+      border-bottom: 2px solid transparent;
+      transition: all 0.15s;
+    }
+    .view-tab:hover { color: var(--text); }
+    .view-tab.active {
+      color: var(--accent);
+      border-bottom-color: var(--accent);
+    }
+    .view-panel { display: none; }
+    .view-panel.active { display: flex; flex-direction: column; flex: 1; overflow: hidden; }
+
+    /* ---- Benchmark view ---- */
+    .benchmark-view {
+      padding: 1.5rem 2rem;
+      overflow-y: auto;
+      flex: 1;
+    }
+    .benchmark-table {
+      border-collapse: collapse;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      font-size: 0.8125rem;
+      width: 100%;
+      margin-bottom: 1.5rem;
+    }
+    .benchmark-table th, .benchmark-table td {
+      padding: 0.625rem 0.75rem;
+      text-align: left;
+      border: 1px solid var(--border);
+    }
+    .benchmark-table th {
+      font-family: 'Poppins', sans-serif;
+      background: var(--header-bg);
+      color: var(--header-text);
+      font-weight: 500;
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .benchmark-table tr:hover { background: var(--bg); }
+    .benchmark-table tr.benchmark-row-with { background: rgba(33, 150, 243, 0.06); }
+    .benchmark-table tr.benchmark-row-without { background: rgba(255, 193, 7, 0.06); }
+    .benchmark-table tr.benchmark-row-with:hover { background: rgba(33, 150, 243, 0.12); }
+    .benchmark-table tr.benchmark-row-without:hover { background: rgba(255, 193, 7, 0.12); }
+    .benchmark-table tr.benchmark-row-avg { font-weight: 600; border-top: 2px solid var(--border); }
+    .benchmark-table tr.benchmark-row-avg.benchmark-row-with { background: rgba(33, 150, 243, 0.12); }
+    .benchmark-table tr.benchmark-row-avg.benchmark-row-without { background: rgba(255, 193, 7, 0.12); }
+    .benchmark-delta-positive { color: var(--green); font-weight: 600; }
+    .benchmark-delta-negative { color: var(--red); font-weight: 600; }
+    .benchmark-notes {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1rem;
+    }
+    .benchmark-notes h3 {
+      font-family: 'Poppins', sans-serif;
+      font-size: 0.875rem;
+      margin-bottom: 0.75rem;
+    }
+    .benchmark-notes ul {
+      list-style: disc;
+      padding-left: 1.25rem;
+    }
+    .benchmark-notes li {
+      font-size: 0.8125rem;
+      line-height: 1.6;
+      margin-bottom: 0.375rem;
+    }
+    .benchmark-empty {
+      color: var(--text-muted);
+      font-style: italic;
+      text-align: center;
+      padding: 3rem;
+    }
+
+    /* ---- Navigation ---- */
+    .nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 1rem 2rem;
+      border-top: 1px solid var(--border);
+      background: var(--surface);
+      flex-shrink: 0;
+    }
+    .nav-btn {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.5rem 1.25rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: var(--text);
+      transition: all 0.15s;
+    }
+    .nav-btn:hover:not(:disabled) {
+      background: var(--bg);
+      border-color: var(--text-muted);
+    }
+    .nav-btn:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+    .done-btn {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.5rem 1.5rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      color: var(--text);
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 500;
+      transition: all 0.15s;
+    }
+    .done-btn:hover {
+      background: var(--bg);
+      border-color: var(--text-muted);
+    }
+    .done-btn.ready {
+      border: none;
+      background: var(--accent);
+      color: white;
+      font-weight: 600;
+    }
+    .done-btn.ready:hover {
+      background: var(--accent-hover);
+    }
+    /* ---- Done overlay ---- */
+    .done-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.5);
+      z-index: 100;
+      justify-content: center;
+      align-items: center;
+    }
+    .done-overlay.visible {
+      display: flex;
+    }
+    .done-card {
+      background: var(--surface);
+      border-radius: 12px;
+      padding: 2rem 3rem;
+      text-align: center;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+      max-width: 500px;
+    }
+    .done-card h2 {
+      font-size: 1.5rem;
+      margin-bottom: 0.5rem;
+    }
+    .done-card p {
+      color: var(--text-muted);
+      margin-bottom: 1.5rem;
+      line-height: 1.5;
+    }
+    .done-card .btn-row {
+      display: flex;
+      gap: 0.5rem;
+      justify-content: center;
+    }
+    .done-card button {
+      padding: 0.5rem 1.25rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      cursor: pointer;
+      font-size: 0.875rem;
+    }
+    .done-card button:hover {
+      background: var(--bg);
+    }
+    /* ---- Toast ---- */
+    .toast {
+      position: fixed;
+      bottom: 5rem;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--header-bg);
+      color: var(--header-text);
+      padding: 0.625rem 1.25rem;
+      border-radius: var(--radius);
+      font-size: 0.875rem;
+      opacity: 0;
+      transition: opacity 0.3s;
+      pointer-events: none;
+      z-index: 200;
+    }
+    .toast.visible {
+      opacity: 1;
+    }
+  </style>
+</head>
+<body>
+  <div id="app" style="height:100vh; display:flex; flex-direction:column;">
+    <div class="header">
+      <div>
+        <h1>Eval Review: <span id="skill-name"></span></h1>
+        <div class="instructions">Review each output and leave feedback below. Navigate with arrow keys or buttons. When done, copy feedback and paste into Claude Code.</div>
+      </div>
+      <div class="progress" id="progress"></div>
+    </div>
+
+    <!-- View tabs (only shown when benchmark data exists) -->
+    <div class="view-tabs" id="view-tabs" style="display:none;">
+      <button class="view-tab active" onclick="switchView('outputs')">Outputs</button>
+      <button class="view-tab" onclick="switchView('benchmark')">Benchmark</button>
+    </div>
+
+    <!-- Outputs panel (qualitative review) -->
+    <div class="view-panel active" id="panel-outputs">
+    <div class="main">
+      <!-- Prompt -->
+      <div class="section">
+        <div class="section-header">Prompt <span class="config-badge" id="config-badge" style="display:none;"></span></div>
+        <div class="section-body">
+          <div class="prompt-text" id="prompt-text"></div>
+        </div>
+      </div>
+
+      <!-- Outputs -->
+      <div class="section">
+        <div class="section-header">Output</div>
+        <div class="section-body" id="outputs-body">
+          <div class="empty-state">No output files found</div>
+        </div>
+      </div>
+
+      <!-- Previous Output (collapsible) -->
+      <div class="section" id="prev-outputs-section" style="display:none;">
+        <div class="section-header">
+          <div class="grades-toggle" onclick="togglePrevOutputs()">
+            <span class="arrow" id="prev-outputs-arrow">&#9654;</span>
+            Previous Output
+          </div>
+        </div>
+        <div class="grades-content" id="prev-outputs-content"></div>
+      </div>
+
+      <!-- Grades (collapsible) -->
+      <div class="section" id="grades-section" style="display:none;">
+        <div class="section-header">
+          <div class="grades-toggle" onclick="toggleGrades()">
+            <span class="arrow" id="grades-arrow">&#9654;</span>
+            Formal Grades
+          </div>
+        </div>
+        <div class="grades-content" id="grades-content"></div>
+      </div>
+
+      <!-- Feedback -->
+      <div class="section">
+        <div class="section-header">Your Feedback</div>
+        <div class="section-body">
+          <textarea
+            class="feedback-textarea"
+            id="feedback"
+            placeholder="What do you think of this output? Any issues, suggestions, or things that look great?"
+          ></textarea>
+          <div class="feedback-status" id="feedback-status"></div>
+          <div class="prev-feedback" id="prev-feedback" style="display:none;">
+            <div class="prev-feedback-label">Previous feedback</div>
+            <div id="prev-feedback-text"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="nav" id="outputs-nav">
+      <button class="nav-btn" id="prev-btn" onclick="navigate(-1)">&#8592; Previous</button>
+      <button class="done-btn" id="done-btn" onclick="showDoneDialog()">Submit All Reviews</button>
+      <button class="nav-btn" id="next-btn" onclick="navigate(1)">Next &#8594;</button>
+    </div>
+    </div><!-- end panel-outputs -->
+
+    <!-- Benchmark panel (quantitative stats) -->
+    <div class="view-panel" id="panel-benchmark">
+      <div class="benchmark-view" id="benchmark-content">
+        <div class="benchmark-empty">No benchmark data available. Run a benchmark to see quantitative results here.</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Done overlay -->
+  <div class="done-overlay" id="done-overlay">
+    <div class="done-card">
+      <h2>Review Complete</h2>
+      <p>Your feedback has been saved. Go back to your Claude Code session and tell Claude you're done reviewing.</p>
+      <div class="btn-row">
+        <button onclick="closeDoneDialog()">OK</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Toast -->
+  <div class="toast" id="toast"></div>
+
+  <script>
+    // ---- Embedded data (injected by generate_review.py) ----
+    /*__EMBEDDED_DATA__*/
+
+    // ---- State ----
+    let feedbackMap = {};  // run_id -> feedback text
+    let currentIndex = 0;
+    let visitedRuns = new Set();
+
+    // ---- Init ----
+    async function init() {
+      // Load saved feedback from server — but only if this isn't a fresh
+      // iteration (indicated by previous_feedback being present). When
+      // previous feedback exists, the feedback.json on disk is stale from
+      // the prior iteration and should not pre-fill the textareas.
+      const hasPrevious = Object.keys(EMBEDDED_DATA.previous_feedback || {}).length > 0
+        || Object.keys(EMBEDDED_DATA.previous_outputs || {}).length > 0;
+      if (!hasPrevious) {
+        try {
+          const resp = await fetch("/api/feedback");
+          const data = await resp.json();
+          if (data.reviews) {
+            for (const r of data.reviews) feedbackMap[r.run_id] = r.feedback;
+          }
+        } catch { /* first run, no feedback yet */ }
+      }
+
+      document.getElementById("skill-name").textContent = EMBEDDED_DATA.skill_name;
+      showRun(0);
+
+      // Wire up feedback auto-save
+      const textarea = document.getElementById("feedback");
+      let saveTimeout = null;
+      textarea.addEventListener("input", () => {
+        clearTimeout(saveTimeout);
+        document.getElementById("feedback-status").textContent = "";
+        saveTimeout = setTimeout(() => saveCurrentFeedback(), 800);
+      });
+    }
+
+    // ---- Navigation ----
+    function navigate(delta) {
+      const newIndex = currentIndex + delta;
+      if (newIndex >= 0 && newIndex < EMBEDDED_DATA.runs.length) {
+        saveCurrentFeedback();
+        showRun(newIndex);
+      }
+    }
+
+    function updateNavButtons() {
+      document.getElementById("prev-btn").disabled = currentIndex === 0;
+      document.getElementById("next-btn").disabled =
+        currentIndex === EMBEDDED_DATA.runs.length - 1;
+    }
+
+    // ---- Show a run ----
+    function showRun(index) {
+      currentIndex = index;
+      const run = EMBEDDED_DATA.runs[index];
+
+      // Progress
+      document.getElementById("progress").textContent =
+        `${index + 1} of ${EMBEDDED_DATA.runs.length}`;
+
+      // Prompt
+      document.getElementById("prompt-text").textContent = run.prompt;
+
+      // Config badge
+      const badge = document.getElementById("config-badge");
+      const configMatch = run.id.match(/(with_skill|without_skill|new_skill|old_skill)/);
+      if (configMatch) {
+        const config = configMatch[1];
+        const isBaseline = config === "without_skill" || config === "old_skill";
+        badge.textContent = config.replace(/_/g, " ");
+        badge.className = "config-badge " + (isBaseline ? "config-baseline" : "config-primary");
+        badge.style.display = "inline-block";
+      } else {
+        badge.style.display = "none";
+      }
+
+      // Outputs
+      renderOutputs(run);
+
+      // Previous outputs
+      renderPrevOutputs(run);
+
+      // Grades
+      renderGrades(run);
+
+      // Previous feedback
+      const prevFb = (EMBEDDED_DATA.previous_feedback || {})[run.id];
+      const prevEl = document.getElementById("prev-feedback");
+      if (prevFb) {
+        document.getElementById("prev-feedback-text").textContent = prevFb;
+        prevEl.style.display = "block";
+      } else {
+        prevEl.style.display = "none";
+      }
+
+      // Feedback
+      document.getElementById("feedback").value = feedbackMap[run.id] || "";
+      document.getElementById("feedback-status").textContent = "";
+
+      updateNavButtons();
+
+      // Track visited runs and promote done button when all visited
+      visitedRuns.add(index);
+      const doneBtn = document.getElementById("done-btn");
+      if (visitedRuns.size >= EMBEDDED_DATA.runs.length) {
+        doneBtn.classList.add("ready");
+      }
+
+      // Scroll main content to top
+      document.querySelector(".main").scrollTop = 0;
+    }
+
+    // ---- Render outputs ----
+    function renderOutputs(run) {
+      const container = document.getElementById("outputs-body");
+      container.innerHTML = "";
+
+      const outputs = run.outputs || [];
+      if (outputs.length === 0) {
+        container.innerHTML = '<div class="empty-state">No output files</div>';
+        return;
+      }
+
+      for (const file of outputs) {
+        const fileDiv = document.createElement("div");
+        fileDiv.className = "output-file";
+
+        // Always show file header with download link
+        const header = document.createElement("div");
+        header.className = "output-file-header";
+        const nameSpan = document.createElement("span");
+        nameSpan.textContent = file.name;
+        header.appendChild(nameSpan);
+        const dlBtn = document.createElement("a");
+        dlBtn.className = "dl-btn";
+        dlBtn.textContent = "Download";
+        dlBtn.download = file.name;
+        dlBtn.href = getDownloadUri(file);
+        header.appendChild(dlBtn);
+        fileDiv.appendChild(header);
+
+        const content = document.createElement("div");
+        content.className = "output-file-content";
+
+        if (file.type === "text") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          content.appendChild(pre);
+        } else if (file.type === "image") {
+          const img = document.createElement("img");
+          img.src = file.data_uri;
+          img.alt = file.name;
+          content.appendChild(img);
+        } else if (file.type === "pdf") {
+          const iframe = document.createElement("iframe");
+          iframe.src = file.data_uri;
+          content.appendChild(iframe);
+        } else if (file.type === "xlsx") {
+          renderXlsx(content, file.data_b64);
+        } else if (file.type === "binary") {
+          const a = document.createElement("a");
+          a.className = "download-link";
+          a.href = file.data_uri;
+          a.download = file.name;
+          a.textContent = "Download " + file.name;
+          content.appendChild(a);
+        } else if (file.type === "error") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          pre.style.color = "var(--red)";
+          content.appendChild(pre);
+        }
+
+        fileDiv.appendChild(content);
+        container.appendChild(fileDiv);
+      }
+    }
+
+    // ---- XLSX rendering via SheetJS ----
+    function renderXlsx(container, b64Data) {
+      try {
+        const raw = Uint8Array.from(atob(b64Data), c => c.charCodeAt(0));
+        const wb = XLSX.read(raw, { type: "array" });
+
+        for (let i = 0; i < wb.SheetNames.length; i++) {
+          const sheetName = wb.SheetNames[i];
+          const ws = wb.Sheets[sheetName];
+
+          if (wb.SheetNames.length > 1) {
+            const sheetLabel = document.createElement("div");
+            sheetLabel.style.cssText =
+              "font-weight:600; font-size:0.8rem; color:#b0aea5; margin-top:0.5rem; margin-bottom:0.25rem;";
+            sheetLabel.textContent = "Sheet: " + sheetName;
+            container.appendChild(sheetLabel);
+          }
+
+          const htmlStr = XLSX.utils.sheet_to_html(ws, { editable: false });
+          const wrapper = document.createElement("div");
+          wrapper.innerHTML = htmlStr;
+          container.appendChild(wrapper);
+        }
+      } catch (err) {
+        container.textContent = "Error rendering spreadsheet: " + err.message;
+      }
+    }
+
+    // ---- Grades ----
+    function renderGrades(run) {
+      const section = document.getElementById("grades-section");
+      const content = document.getElementById("grades-content");
+
+      if (!run.grading) {
+        section.style.display = "none";
+        return;
+      }
+
+      const grading = run.grading;
+      section.style.display = "block";
+      // Reset to collapsed
+      content.classList.remove("open");
+      document.getElementById("grades-arrow").classList.remove("open");
+
+      const summary = grading.summary || {};
+      const expectations = grading.expectations || [];
+
+      let html = '<div style="padding: 1rem;">';
+
+      // Summary line
+      const passRate = summary.pass_rate != null
+        ? Math.round(summary.pass_rate * 100) + "%"
+        : "?";
+      const badgeClass = summary.pass_rate >= 0.8 ? "grade-pass" : summary.pass_rate >= 0.5 ? "" : "grade-fail";
+      html += '<div class="grades-summary">';
+      html += '<span class="grade-badge ' + badgeClass + '">' + passRate + '</span>';
+      html += '<span>' + (summary.passed || 0) + ' passed, ' + (summary.failed || 0) + ' failed of ' + (summary.total || 0) + '</span>';
+      html += '</div>';
+
+      // Assertions list
+      html += '<ul class="assertion-list">';
+      for (const exp of expectations) {
+        const statusClass = exp.passed ? "pass" : "fail";
+        const statusIcon = exp.passed ? "\u2713" : "\u2717";
+        html += '<li class="assertion-item">';
+        html += '<span class="assertion-status ' + statusClass + '">' + statusIcon + '</span>';
+        html += '<span>' + escapeHtml(exp.text) + '</span>';
+        if (exp.evidence) {
+          html += '<div class="assertion-evidence">' + escapeHtml(exp.evidence) + '</div>';
+        }
+        html += '</li>';
+      }
+      html += '</ul>';
+
+      html += '</div>';
+      content.innerHTML = html;
+    }
+
+    function toggleGrades() {
+      const content = document.getElementById("grades-content");
+      const arrow = document.getElementById("grades-arrow");
+      content.classList.toggle("open");
+      arrow.classList.toggle("open");
+    }
+
+    // ---- Previous outputs (collapsible) ----
+    function renderPrevOutputs(run) {
+      const section = document.getElementById("prev-outputs-section");
+      const content = document.getElementById("prev-outputs-content");
+      const prevOutputs = (EMBEDDED_DATA.previous_outputs || {})[run.id];
+
+      if (!prevOutputs || prevOutputs.length === 0) {
+        section.style.display = "none";
+        return;
+      }
+
+      section.style.display = "block";
+      // Reset to collapsed
+      content.classList.remove("open");
+      document.getElementById("prev-outputs-arrow").classList.remove("open");
+
+      // Render the files into the content area
+      content.innerHTML = "";
+      const wrapper = document.createElement("div");
+      wrapper.style.padding = "1rem";
+
+      for (const file of prevOutputs) {
+        const fileDiv = document.createElement("div");
+        fileDiv.className = "output-file";
+
+        const header = document.createElement("div");
+        header.className = "output-file-header";
+        const nameSpan = document.createElement("span");
+        nameSpan.textContent = file.name;
+        header.appendChild(nameSpan);
+        const dlBtn = document.createElement("a");
+        dlBtn.className = "dl-btn";
+        dlBtn.textContent = "Download";
+        dlBtn.download = file.name;
+        dlBtn.href = getDownloadUri(file);
+        header.appendChild(dlBtn);
+        fileDiv.appendChild(header);
+
+        const fc = document.createElement("div");
+        fc.className = "output-file-content";
+
+        if (file.type === "text") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          fc.appendChild(pre);
+        } else if (file.type === "image") {
+          const img = document.createElement("img");
+          img.src = file.data_uri;
+          img.alt = file.name;
+          fc.appendChild(img);
+        } else if (file.type === "pdf") {
+          const iframe = document.createElement("iframe");
+          iframe.src = file.data_uri;
+          fc.appendChild(iframe);
+        } else if (file.type === "xlsx") {
+          renderXlsx(fc, file.data_b64);
+        } else if (file.type === "binary") {
+          const a = document.createElement("a");
+          a.className = "download-link";
+          a.href = file.data_uri;
+          a.download = file.name;
+          a.textContent = "Download " + file.name;
+          fc.appendChild(a);
+        }
+
+        fileDiv.appendChild(fc);
+        wrapper.appendChild(fileDiv);
+      }
+
+      content.appendChild(wrapper);
+    }
+
+    function togglePrevOutputs() {
+      const content = document.getElementById("prev-outputs-content");
+      const arrow = document.getElementById("prev-outputs-arrow");
+      content.classList.toggle("open");
+      arrow.classList.toggle("open");
+    }
+
+    // ---- Feedback (saved to server -> feedback.json) ----
+    function saveCurrentFeedback() {
+      const run = EMBEDDED_DATA.runs[currentIndex];
+      const text = document.getElementById("feedback").value;
+
+      if (text.trim() === "") {
+        delete feedbackMap[run.id];
+      } else {
+        feedbackMap[run.id] = text;
+      }
+
+      // Build reviews array from map
+      const reviews = [];
+      for (const [run_id, feedback] of Object.entries(feedbackMap)) {
+        if (feedback.trim()) {
+          reviews.push({ run_id, feedback, timestamp: new Date().toISOString() });
+        }
+      }
+
+      fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reviews, status: "in_progress" }),
+      }).then(() => {
+        document.getElementById("feedback-status").textContent = "Saved";
+      }).catch(() => {
+        // Static mode or server unavailable — no-op on auto-save,
+        // feedback will be downloaded on final submit
+        document.getElementById("feedback-status").textContent = "Will download on submit";
+      });
+    }
+
+    // ---- Done ----
+    function showDoneDialog() {
+      // Save current textarea to feedbackMap (but don't POST yet)
+      const run = EMBEDDED_DATA.runs[currentIndex];
+      const text = document.getElementById("feedback").value;
+      if (text.trim() === "") {
+        delete feedbackMap[run.id];
+      } else {
+        feedbackMap[run.id] = text;
+      }
+
+      // POST once with status: complete — include ALL runs so the model
+      // can distinguish "no feedback" (looks good) from "not reviewed"
+      const reviews = [];
+      const ts = new Date().toISOString();
+      for (const r of EMBEDDED_DATA.runs) {
+        reviews.push({ run_id: r.id, feedback: feedbackMap[r.id] || "", timestamp: ts });
+      }
+      const payload = JSON.stringify({ reviews, status: "complete" }, null, 2);
+      fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: payload,
+      }).then(() => {
+        document.getElementById("done-overlay").classList.add("visible");
+      }).catch(() => {
+        // Server not available (static mode) — download as file
+        const blob = new Blob([payload], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "feedback.json";
+        a.click();
+        URL.revokeObjectURL(url);
+        document.getElementById("done-overlay").classList.add("visible");
+      });
+    }
+
+    function closeDoneDialog() {
+      // Reset status back to in_progress
+      saveCurrentFeedback();
+      document.getElementById("done-overlay").classList.remove("visible");
+    }
+
+    // ---- Toast ----
+    function showToast(message) {
+      const toast = document.getElementById("toast");
+      toast.textContent = message;
+      toast.classList.add("visible");
+      setTimeout(() => toast.classList.remove("visible"), 2000);
+    }
+
+    // ---- Keyboard nav ----
+    document.addEventListener("keydown", (e) => {
+      // Don't capture when typing in textarea
+      if (e.target.tagName === "TEXTAREA") return;
+
+      if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+        e.preventDefault();
+        navigate(-1);
+      } else if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+        e.preventDefault();
+        navigate(1);
+      }
+    });
+
+    // ---- Util ----
+    function getDownloadUri(file) {
+      if (file.data_uri) return file.data_uri;
+      if (file.data_b64) return "data:application/octet-stream;base64," + file.data_b64;
+      if (file.type === "text") return "data:text/plain;charset=utf-8," + encodeURIComponent(file.content);
+      return "#";
+    }
+
+    function escapeHtml(text) {
+      const div = document.createElement("div");
+      div.textContent = text;
+      return div.innerHTML;
+    }
+
+    // ---- View switching ----
+    function switchView(view) {
+      document.querySelectorAll(".view-tab").forEach(t => t.classList.remove("active"));
+      document.querySelectorAll(".view-panel").forEach(p => p.classList.remove("active"));
+      document.querySelector(`[onclick="switchView('${view}')"]`).classList.add("active");
+      document.getElementById("panel-" + view).classList.add("active");
+    }
+
+    // ---- Benchmark rendering ----
+    function renderBenchmark() {
+      const data = EMBEDDED_DATA.benchmark;
+      if (!data) return;
+
+      // Show the tabs
+      document.getElementById("view-tabs").style.display = "flex";
+
+      const container = document.getElementById("benchmark-content");
+      const summary = data.run_summary || {};
+      const metadata = data.metadata || {};
+      const notes = data.notes || [];
+
+      let html = "";
+
+      // Header
+      html += "<h2 style='font-family: Poppins, sans-serif; margin-bottom: 0.5rem;'>Benchmark Results</h2>";
+      html += "<p style='color: var(--text-muted); font-size: 0.875rem; margin-bottom: 1.25rem;'>";
+      if (metadata.skill_name) html += "<strong>" + escapeHtml(metadata.skill_name) + "</strong> &mdash; ";
+      if (metadata.timestamp) html += metadata.timestamp + " &mdash; ";
+      if (metadata.evals_run) html += "Evals: " + metadata.evals_run.join(", ") + " &mdash; ";
+      html += (metadata.runs_per_configuration || "?") + " runs per configuration";
+      html += "</p>";
+
+      // Summary table
+      html += '<table class="benchmark-table">';
+
+      function fmtStat(stat, pct) {
+        if (!stat) return "—";
+        const suffix = pct ? "%" : "";
+        const m = pct ? (stat.mean * 100).toFixed(0) : stat.mean.toFixed(1);
+        const s = pct ? (stat.stddev * 100).toFixed(0) : stat.stddev.toFixed(1);
+        return m + suffix + " ± " + s + suffix;
+      }
+
+      function deltaClass(val) {
+        if (!val) return "";
+        const n = parseFloat(val);
+        if (n > 0) return "benchmark-delta-positive";
+        if (n < 0) return "benchmark-delta-negative";
+        return "";
+      }
+
+      // Discover config names dynamically (everything except "delta")
+      const configs = Object.keys(summary).filter(k => k !== "delta");
+      const configA = configs[0] || "config_a";
+      const configB = configs[1] || "config_b";
+      const labelA = configA.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+      const labelB = configB.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+      const a = summary[configA] || {};
+      const b = summary[configB] || {};
+      const delta = summary.delta || {};
+
+      html += "<thead><tr><th>Metric</th><th>" + escapeHtml(labelA) + "</th><th>" + escapeHtml(labelB) + "</th><th>Delta</th></tr></thead>";
+      html += "<tbody>";
+
+      html += "<tr><td><strong>Pass Rate</strong></td>";
+      html += "<td>" + fmtStat(a.pass_rate, true) + "</td>";
+      html += "<td>" + fmtStat(b.pass_rate, true) + "</td>";
+      html += '<td class="' + deltaClass(delta.pass_rate) + '">' + (delta.pass_rate || "—") + "</td></tr>";
+
+      // Time (only show row if data exists)
+      if (a.time_seconds || b.time_seconds) {
+        html += "<tr><td><strong>Time (s)</strong></td>";
+        html += "<td>" + fmtStat(a.time_seconds, false) + "</td>";
+        html += "<td>" + fmtStat(b.time_seconds, false) + "</td>";
+        html += '<td class="' + deltaClass(delta.time_seconds) + '">' + (delta.time_seconds ? delta.time_seconds + "s" : "—") + "</td></tr>";
+      }
+
+      // Tokens (only show row if data exists)
+      if (a.tokens || b.tokens) {
+        html += "<tr><td><strong>Tokens</strong></td>";
+        html += "<td>" + fmtStat(a.tokens, false) + "</td>";
+        html += "<td>" + fmtStat(b.tokens, false) + "</td>";
+        html += '<td class="' + deltaClass(delta.tokens) + '">' + (delta.tokens || "—") + "</td></tr>";
+      }
+
+      html += "</tbody></table>";
+
+      // Per-eval breakdown (if runs data available)
+      const runs = data.runs || [];
+      if (runs.length > 0) {
+        const evalIds = [...new Set(runs.map(r => r.eval_id))].sort((a, b) => a - b);
+
+        html += "<h3 style='font-family: Poppins, sans-serif; margin-bottom: 0.75rem;'>Per-Eval Breakdown</h3>";
+
+        const hasTime = runs.some(r => r.result && r.result.time_seconds != null);
+        const hasErrors = runs.some(r => r.result && r.result.errors > 0);
+
+        for (const evalId of evalIds) {
+          const evalRuns = runs.filter(r => r.eval_id === evalId);
+          const evalName = evalRuns[0] && evalRuns[0].eval_name ? evalRuns[0].eval_name : "Eval " + evalId;
+
+          html += "<h4 style='font-family: Poppins, sans-serif; margin: 1rem 0 0.5rem; color: var(--text);'>" + escapeHtml(evalName) + "</h4>";
+          html += '<table class="benchmark-table">';
+          html += "<thead><tr><th>Config</th><th>Run</th><th>Pass Rate</th>";
+          if (hasTime) html += "<th>Time (s)</th>";
+          if (hasErrors) html += "<th>Crashes During Execution</th>";
+          html += "</tr></thead>";
+          html += "<tbody>";
+
+          // Group by config and render with average rows
+          const configGroups = [...new Set(evalRuns.map(r => r.configuration))];
+          for (let ci = 0; ci < configGroups.length; ci++) {
+            const config = configGroups[ci];
+            const configRuns = evalRuns.filter(r => r.configuration === config);
+            if (configRuns.length === 0) continue;
+
+            const rowClass = ci === 0 ? "benchmark-row-with" : "benchmark-row-without";
+            const configLabel = config.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+
+            for (const run of configRuns) {
+              const r = run.result || {};
+              const prClass = r.pass_rate >= 0.8 ? "benchmark-delta-positive" : r.pass_rate < 0.5 ? "benchmark-delta-negative" : "";
+              html += '<tr class="' + rowClass + '">';
+              html += "<td>" + configLabel + "</td>";
+              html += "<td>" + run.run_number + "</td>";
+              html += '<td class="' + prClass + '">' + ((r.pass_rate || 0) * 100).toFixed(0) + "% (" + (r.passed || 0) + "/" + (r.total || 0) + ")</td>";
+              if (hasTime) html += "<td>" + (r.time_seconds != null ? r.time_seconds.toFixed(1) : "—") + "</td>";
+              if (hasErrors) html += "<td>" + (r.errors || 0) + "</td>";
+              html += "</tr>";
+            }
+
+            // Average row
+            const rates = configRuns.map(r => (r.result || {}).pass_rate || 0);
+            const avgRate = rates.reduce((a, b) => a + b, 0) / rates.length;
+            const avgPrClass = avgRate >= 0.8 ? "benchmark-delta-positive" : avgRate < 0.5 ? "benchmark-delta-negative" : "";
+            html += '<tr class="benchmark-row-avg ' + rowClass + '">';
+            html += "<td>" + configLabel + "</td>";
+            html += "<td>Avg</td>";
+            html += '<td class="' + avgPrClass + '">' + (avgRate * 100).toFixed(0) + "%</td>";
+            if (hasTime) {
+              const times = configRuns.map(r => (r.result || {}).time_seconds).filter(t => t != null);
+              html += "<td>" + (times.length ? (times.reduce((a, b) => a + b, 0) / times.length).toFixed(1) : "—") + "</td>";
+            }
+            if (hasErrors) html += "<td></td>";
+            html += "</tr>";
+          }
+          html += "</tbody></table>";
+
+          // Per-assertion detail for this eval
+          const runsWithExpectations = {};
+          for (const config of configGroups) {
+            runsWithExpectations[config] = evalRuns.filter(r => r.configuration === config && r.expectations && r.expectations.length > 0);
+          }
+          const hasAnyExpectations = Object.values(runsWithExpectations).some(runs => runs.length > 0);
+          if (hasAnyExpectations) {
+            // Collect all unique assertion texts across all configs
+            const allAssertions = [];
+            const seen = new Set();
+            for (const config of configGroups) {
+              for (const run of runsWithExpectations[config]) {
+                for (const exp of (run.expectations || [])) {
+                  if (!seen.has(exp.text)) {
+                    seen.add(exp.text);
+                    allAssertions.push(exp.text);
+                  }
+                }
+              }
+            }
+
+            html += '<table class="benchmark-table" style="margin-top: 0.5rem;">';
+            html += "<thead><tr><th>Assertion</th>";
+            for (const config of configGroups) {
+              const label = config.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+              html += "<th>" + escapeHtml(label) + "</th>";
+            }
+            html += "</tr></thead><tbody>";
+
+            for (const assertionText of allAssertions) {
+              html += "<tr><td>" + escapeHtml(assertionText) + "</td>";
+
+              for (const config of configGroups) {
+                html += "<td>";
+                for (const run of runsWithExpectations[config]) {
+                  const exp = (run.expectations || []).find(e => e.text === assertionText);
+                  if (exp) {
+                    const cls = exp.passed ? "benchmark-delta-positive" : "benchmark-delta-negative";
+                    const icon = exp.passed ? "\u2713" : "\u2717";
+                    html += '<span class="' + cls + '" title="Run ' + run.run_number + ': ' + escapeHtml(exp.evidence || "") + '">' + icon + "</span> ";
+                  } else {
+                    html += "— ";
+                  }
+                }
+                html += "</td>";
+              }
+              html += "</tr>";
+            }
+            html += "</tbody></table>";
+          }
+        }
+      }
+
+      // Notes
+      if (notes.length > 0) {
+        html += '<div class="benchmark-notes">';
+        html += "<h3>Analysis Notes</h3>";
+        html += "<ul>";
+        for (const note of notes) {
+          html += "<li>" + escapeHtml(note) + "</li>";
+        }
+        html += "</ul></div>";
+      }
+
+      container.innerHTML = html;
+    }
+
+    // ---- Start ----
+    init();
+    renderBenchmark();
+  </script>
+</body>
+</html>

--- a/.agents/skills/skill-creator/references/schemas.md
+++ b/.agents/skills/skill-creator/references/schemas.md
@@ -1,0 +1,430 @@
+# JSON Schemas
+
+This document defines the JSON schemas used by skill-creator.
+
+---
+
+## evals.json
+
+Defines the evals for a skill. Located at `evals/evals.json` within the skill directory.
+
+```json
+{
+  "skill_name": "example-skill",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "User's example prompt",
+      "expected_output": "Description of expected result",
+      "files": ["evals/files/sample1.pdf"],
+      "expectations": [
+        "The output includes X",
+        "The skill used script Y"
+      ]
+    }
+  ]
+}
+```
+
+**Fields:**
+- `skill_name`: Name matching the skill's frontmatter
+- `evals[].id`: Unique integer identifier
+- `evals[].prompt`: The task to execute
+- `evals[].expected_output`: Human-readable description of success
+- `evals[].files`: Optional list of input file paths (relative to skill root)
+- `evals[].expectations`: List of verifiable statements
+
+---
+
+## history.json
+
+Tracks version progression in Improve mode. Located at workspace root.
+
+```json
+{
+  "started_at": "2026-01-15T10:30:00Z",
+  "skill_name": "pdf",
+  "current_best": "v2",
+  "iterations": [
+    {
+      "version": "v0",
+      "parent": null,
+      "expectation_pass_rate": 0.65,
+      "grading_result": "baseline",
+      "is_current_best": false
+    },
+    {
+      "version": "v1",
+      "parent": "v0",
+      "expectation_pass_rate": 0.75,
+      "grading_result": "won",
+      "is_current_best": false
+    },
+    {
+      "version": "v2",
+      "parent": "v1",
+      "expectation_pass_rate": 0.85,
+      "grading_result": "won",
+      "is_current_best": true
+    }
+  ]
+}
+```
+
+**Fields:**
+- `started_at`: ISO timestamp of when improvement started
+- `skill_name`: Name of the skill being improved
+- `current_best`: Version identifier of the best performer
+- `iterations[].version`: Version identifier (v0, v1, ...)
+- `iterations[].parent`: Parent version this was derived from
+- `iterations[].expectation_pass_rate`: Pass rate from grading
+- `iterations[].grading_result`: "baseline", "won", "lost", or "tie"
+- `iterations[].is_current_best`: Whether this is the current best version
+
+---
+
+## grading.json
+
+Output from the grader agent. Located at `<run-dir>/grading.json`.
+
+```json
+{
+  "expectations": [
+    {
+      "text": "The output includes the name 'John Smith'",
+      "passed": true,
+      "evidence": "Found in transcript Step 3: 'Extracted names: John Smith, Sarah Johnson'"
+    },
+    {
+      "text": "The spreadsheet has a SUM formula in cell B10",
+      "passed": false,
+      "evidence": "No spreadsheet was created. The output was a text file."
+    }
+  ],
+  "summary": {
+    "passed": 2,
+    "failed": 1,
+    "total": 3,
+    "pass_rate": 0.67
+  },
+  "execution_metrics": {
+    "tool_calls": {
+      "Read": 5,
+      "Write": 2,
+      "Bash": 8
+    },
+    "total_tool_calls": 15,
+    "total_steps": 6,
+    "errors_encountered": 0,
+    "output_chars": 12450,
+    "transcript_chars": 3200
+  },
+  "timing": {
+    "executor_duration_seconds": 165.0,
+    "grader_duration_seconds": 26.0,
+    "total_duration_seconds": 191.0
+  },
+  "claims": [
+    {
+      "claim": "The form has 12 fillable fields",
+      "type": "factual",
+      "verified": true,
+      "evidence": "Counted 12 fields in field_info.json"
+    }
+  ],
+  "user_notes_summary": {
+    "uncertainties": ["Used 2023 data, may be stale"],
+    "needs_review": [],
+    "workarounds": ["Fell back to text overlay for non-fillable fields"]
+  },
+  "eval_feedback": {
+    "suggestions": [
+      {
+        "assertion": "The output includes the name 'John Smith'",
+        "reason": "A hallucinated document that mentions the name would also pass"
+      }
+    ],
+    "overall": "Assertions check presence but not correctness."
+  }
+}
+```
+
+**Fields:**
+- `expectations[]`: Graded expectations with evidence
+- `summary`: Aggregate pass/fail counts
+- `execution_metrics`: Tool usage and output size (from executor's metrics.json)
+- `timing`: Wall clock timing (from timing.json)
+- `claims`: Extracted and verified claims from the output
+- `user_notes_summary`: Issues flagged by the executor
+- `eval_feedback`: (optional) Improvement suggestions for the evals, only present when the grader identifies issues worth raising
+
+---
+
+## metrics.json
+
+Output from the executor agent. Located at `<run-dir>/outputs/metrics.json`.
+
+```json
+{
+  "tool_calls": {
+    "Read": 5,
+    "Write": 2,
+    "Bash": 8,
+    "Edit": 1,
+    "Glob": 2,
+    "Grep": 0
+  },
+  "total_tool_calls": 18,
+  "total_steps": 6,
+  "files_created": ["filled_form.pdf", "field_values.json"],
+  "errors_encountered": 0,
+  "output_chars": 12450,
+  "transcript_chars": 3200
+}
+```
+
+**Fields:**
+- `tool_calls`: Count per tool type
+- `total_tool_calls`: Sum of all tool calls
+- `total_steps`: Number of major execution steps
+- `files_created`: List of output files created
+- `errors_encountered`: Number of errors during execution
+- `output_chars`: Total character count of output files
+- `transcript_chars`: Character count of transcript
+
+---
+
+## timing.json
+
+Wall clock timing for a run. Located at `<run-dir>/timing.json`.
+
+**How to capture:** When a subagent task completes, the task notification includes `total_tokens` and `duration_ms`. Save these immediately — they are not persisted anywhere else and cannot be recovered after the fact.
+
+```json
+{
+  "total_tokens": 84852,
+  "duration_ms": 23332,
+  "total_duration_seconds": 23.3,
+  "executor_start": "2026-01-15T10:30:00Z",
+  "executor_end": "2026-01-15T10:32:45Z",
+  "executor_duration_seconds": 165.0,
+  "grader_start": "2026-01-15T10:32:46Z",
+  "grader_end": "2026-01-15T10:33:12Z",
+  "grader_duration_seconds": 26.0
+}
+```
+
+---
+
+## benchmark.json
+
+Output from Benchmark mode. Located at `benchmarks/<timestamp>/benchmark.json`.
+
+```json
+{
+  "metadata": {
+    "skill_name": "pdf",
+    "skill_path": "/path/to/pdf",
+    "executor_model": "claude-sonnet-4-20250514",
+    "analyzer_model": "most-capable-model",
+    "timestamp": "2026-01-15T10:30:00Z",
+    "evals_run": [1, 2, 3],
+    "runs_per_configuration": 3
+  },
+
+  "runs": [
+    {
+      "eval_id": 1,
+      "eval_name": "Ocean",
+      "configuration": "with_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 0.85,
+        "passed": 6,
+        "failed": 1,
+        "total": 7,
+        "time_seconds": 42.5,
+        "tokens": 3800,
+        "tool_calls": 18,
+        "errors": 0
+      },
+      "expectations": [
+        {"text": "...", "passed": true, "evidence": "..."}
+      ],
+      "notes": [
+        "Used 2023 data, may be stale",
+        "Fell back to text overlay for non-fillable fields"
+      ]
+    }
+  ],
+
+  "run_summary": {
+    "with_skill": {
+      "pass_rate": {"mean": 0.85, "stddev": 0.05, "min": 0.80, "max": 0.90},
+      "time_seconds": {"mean": 45.0, "stddev": 12.0, "min": 32.0, "max": 58.0},
+      "tokens": {"mean": 3800, "stddev": 400, "min": 3200, "max": 4100}
+    },
+    "without_skill": {
+      "pass_rate": {"mean": 0.35, "stddev": 0.08, "min": 0.28, "max": 0.45},
+      "time_seconds": {"mean": 32.0, "stddev": 8.0, "min": 24.0, "max": 42.0},
+      "tokens": {"mean": 2100, "stddev": 300, "min": 1800, "max": 2500}
+    },
+    "delta": {
+      "pass_rate": "+0.50",
+      "time_seconds": "+13.0",
+      "tokens": "+1700"
+    }
+  },
+
+  "notes": [
+    "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value",
+    "Eval 3 shows high variance (50% ± 40%) - may be flaky or model-dependent",
+    "Without-skill runs consistently fail on table extraction expectations",
+    "Skill adds 13s average execution time but improves pass rate by 50%"
+  ]
+}
+```
+
+**Fields:**
+- `metadata`: Information about the benchmark run
+  - `skill_name`: Name of the skill
+  - `timestamp`: When the benchmark was run
+  - `evals_run`: List of eval names or IDs
+  - `runs_per_configuration`: Number of runs per config (e.g. 3)
+- `runs[]`: Individual run results
+  - `eval_id`: Numeric eval identifier
+  - `eval_name`: Human-readable eval name (used as section header in the viewer)
+  - `configuration`: Must be `"with_skill"` or `"without_skill"` (the viewer uses this exact string for grouping and color coding)
+  - `run_number`: Integer run number (1, 2, 3...)
+  - `result`: Nested object with `pass_rate`, `passed`, `total`, `time_seconds`, `tokens`, `errors`
+- `run_summary`: Statistical aggregates per configuration
+  - `with_skill` / `without_skill`: Each contains `pass_rate`, `time_seconds`, `tokens` objects with `mean` and `stddev` fields
+  - `delta`: Difference strings like `"+0.50"`, `"+13.0"`, `"+1700"`
+- `notes`: Freeform observations from the analyzer
+
+**Important:** The viewer reads these field names exactly. Using `config` instead of `configuration`, or putting `pass_rate` at the top level of a run instead of nested under `result`, will cause the viewer to show empty/zero values. Always reference this schema when generating benchmark.json manually.
+
+---
+
+## comparison.json
+
+Output from blind comparator. Located at `<grading-dir>/comparison-N.json`.
+
+```json
+{
+  "winner": "A",
+  "reasoning": "Output A provides a complete solution with proper formatting and all required fields. Output B is missing the date field and has formatting inconsistencies.",
+  "rubric": {
+    "A": {
+      "content": {
+        "correctness": 5,
+        "completeness": 5,
+        "accuracy": 4
+      },
+      "structure": {
+        "organization": 4,
+        "formatting": 5,
+        "usability": 4
+      },
+      "content_score": 4.7,
+      "structure_score": 4.3,
+      "overall_score": 9.0
+    },
+    "B": {
+      "content": {
+        "correctness": 3,
+        "completeness": 2,
+        "accuracy": 3
+      },
+      "structure": {
+        "organization": 3,
+        "formatting": 2,
+        "usability": 3
+      },
+      "content_score": 2.7,
+      "structure_score": 2.7,
+      "overall_score": 5.4
+    }
+  },
+  "output_quality": {
+    "A": {
+      "score": 9,
+      "strengths": ["Complete solution", "Well-formatted", "All fields present"],
+      "weaknesses": ["Minor style inconsistency in header"]
+    },
+    "B": {
+      "score": 5,
+      "strengths": ["Readable output", "Correct basic structure"],
+      "weaknesses": ["Missing date field", "Formatting inconsistencies", "Partial data extraction"]
+    }
+  },
+  "expectation_results": {
+    "A": {
+      "passed": 4,
+      "total": 5,
+      "pass_rate": 0.80,
+      "details": [
+        {"text": "Output includes name", "passed": true}
+      ]
+    },
+    "B": {
+      "passed": 3,
+      "total": 5,
+      "pass_rate": 0.60,
+      "details": [
+        {"text": "Output includes name", "passed": true}
+      ]
+    }
+  }
+}
+```
+
+---
+
+## analysis.json
+
+Output from post-hoc analyzer. Located at `<grading-dir>/analysis.json`.
+
+```json
+{
+  "comparison_summary": {
+    "winner": "A",
+    "winner_skill": "path/to/winner/skill",
+    "loser_skill": "path/to/loser/skill",
+    "comparator_reasoning": "Brief summary of why comparator chose winner"
+  },
+  "winner_strengths": [
+    "Clear step-by-step instructions for handling multi-page documents",
+    "Included validation script that caught formatting errors"
+  ],
+  "loser_weaknesses": [
+    "Vague instruction 'process the document appropriately' led to inconsistent behavior",
+    "No script for validation, agent had to improvise"
+  ],
+  "instruction_following": {
+    "winner": {
+      "score": 9,
+      "issues": ["Minor: skipped optional logging step"]
+    },
+    "loser": {
+      "score": 6,
+      "issues": [
+        "Did not use the skill's formatting template",
+        "Invented own approach instead of following step 3"
+      ]
+    }
+  },
+  "improvement_suggestions": [
+    {
+      "priority": "high",
+      "category": "instructions",
+      "suggestion": "Replace 'process the document appropriately' with explicit steps",
+      "expected_impact": "Would eliminate ambiguity that caused inconsistent behavior"
+    }
+  ],
+  "transcript_insights": {
+    "winner_execution_pattern": "Read skill -> Followed 5-step process -> Used validation script",
+    "loser_execution_pattern": "Read skill -> Unclear on approach -> Tried 3 different methods"
+  }
+}
+```

--- a/.agents/skills/skill-creator/scripts/aggregate_benchmark.py
+++ b/.agents/skills/skill-creator/scripts/aggregate_benchmark.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""
+Aggregate individual run results into benchmark summary statistics.
+
+Reads grading.json files from run directories and produces:
+- run_summary with mean, stddev, min, max for each metric
+- delta between with_skill and without_skill configurations
+
+Usage:
+    python aggregate_benchmark.py <benchmark_dir>
+
+Example:
+    python aggregate_benchmark.py benchmarks/2026-01-15T10-30-00/
+
+The script supports two directory layouts:
+
+    Workspace layout (from skill-creator iterations):
+    <benchmark_dir>/
+    └── eval-N/
+        ├── with_skill/
+        │   ├── run-1/grading.json
+        │   └── run-2/grading.json
+        └── without_skill/
+            ├── run-1/grading.json
+            └── run-2/grading.json
+
+    Legacy layout (with runs/ subdirectory):
+    <benchmark_dir>/
+    └── runs/
+        └── eval-N/
+            ├── with_skill/
+            │   └── run-1/grading.json
+            └── without_skill/
+                └── run-1/grading.json
+"""
+
+import argparse
+import json
+import math
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def calculate_stats(values: list[float]) -> dict:
+    """Calculate mean, stddev, min, max for a list of values."""
+    if not values:
+        return {"mean": 0.0, "stddev": 0.0, "min": 0.0, "max": 0.0}
+
+    n = len(values)
+    mean = sum(values) / n
+
+    if n > 1:
+        variance = sum((x - mean) ** 2 for x in values) / (n - 1)
+        stddev = math.sqrt(variance)
+    else:
+        stddev = 0.0
+
+    return {
+        "mean": round(mean, 4),
+        "stddev": round(stddev, 4),
+        "min": round(min(values), 4),
+        "max": round(max(values), 4)
+    }
+
+
+def load_run_results(benchmark_dir: Path) -> dict:
+    """
+    Load all run results from a benchmark directory.
+
+    Returns dict keyed by config name (e.g. "with_skill"/"without_skill",
+    or "new_skill"/"old_skill"), each containing a list of run results.
+    """
+    # Support both layouts: eval dirs directly under benchmark_dir, or under runs/
+    runs_dir = benchmark_dir / "runs"
+    if runs_dir.exists():
+        search_dir = runs_dir
+    elif list(benchmark_dir.glob("eval-*")):
+        search_dir = benchmark_dir
+    else:
+        print(f"No eval directories found in {benchmark_dir} or {benchmark_dir / 'runs'}")
+        return {}
+
+    results: dict[str, list] = {}
+
+    for eval_idx, eval_dir in enumerate(sorted(search_dir.glob("eval-*"))):
+        metadata_path = eval_dir / "eval_metadata.json"
+        if metadata_path.exists():
+            try:
+                with open(metadata_path) as mf:
+                    eval_id = json.load(mf).get("eval_id", eval_idx)
+            except (json.JSONDecodeError, OSError):
+                eval_id = eval_idx
+        else:
+            try:
+                eval_id = int(eval_dir.name.split("-")[1])
+            except ValueError:
+                eval_id = eval_idx
+
+        # Discover config directories dynamically rather than hardcoding names
+        for config_dir in sorted(eval_dir.iterdir()):
+            if not config_dir.is_dir():
+                continue
+            # Skip non-config directories (inputs, outputs, etc.)
+            if not list(config_dir.glob("run-*")):
+                continue
+            config = config_dir.name
+            if config not in results:
+                results[config] = []
+
+            for run_dir in sorted(config_dir.glob("run-*")):
+                run_number = int(run_dir.name.split("-")[1])
+                grading_file = run_dir / "grading.json"
+
+                if not grading_file.exists():
+                    print(f"Warning: grading.json not found in {run_dir}")
+                    continue
+
+                try:
+                    with open(grading_file) as f:
+                        grading = json.load(f)
+                except json.JSONDecodeError as e:
+                    print(f"Warning: Invalid JSON in {grading_file}: {e}")
+                    continue
+
+                # Extract metrics
+                result = {
+                    "eval_id": eval_id,
+                    "run_number": run_number,
+                    "pass_rate": grading.get("summary", {}).get("pass_rate", 0.0),
+                    "passed": grading.get("summary", {}).get("passed", 0),
+                    "failed": grading.get("summary", {}).get("failed", 0),
+                    "total": grading.get("summary", {}).get("total", 0),
+                }
+
+                # Extract timing — check grading.json first, then sibling timing.json
+                timing = grading.get("timing", {})
+                result["time_seconds"] = timing.get("total_duration_seconds", 0.0)
+                timing_file = run_dir / "timing.json"
+                if result["time_seconds"] == 0.0 and timing_file.exists():
+                    try:
+                        with open(timing_file) as tf:
+                            timing_data = json.load(tf)
+                        result["time_seconds"] = timing_data.get("total_duration_seconds", 0.0)
+                        result["tokens"] = timing_data.get("total_tokens", 0)
+                    except json.JSONDecodeError:
+                        pass
+
+                # Extract metrics if available
+                metrics = grading.get("execution_metrics", {})
+                result["tool_calls"] = metrics.get("total_tool_calls", 0)
+                if not result.get("tokens"):
+                    result["tokens"] = metrics.get("output_chars", 0)
+                result["errors"] = metrics.get("errors_encountered", 0)
+
+                # Extract expectations — viewer requires fields: text, passed, evidence
+                raw_expectations = grading.get("expectations", [])
+                for exp in raw_expectations:
+                    if "text" not in exp or "passed" not in exp:
+                        print(f"Warning: expectation in {grading_file} missing required fields (text, passed, evidence): {exp}")
+                result["expectations"] = raw_expectations
+
+                # Extract notes from user_notes_summary
+                notes_summary = grading.get("user_notes_summary", {})
+                notes = []
+                notes.extend(notes_summary.get("uncertainties", []))
+                notes.extend(notes_summary.get("needs_review", []))
+                notes.extend(notes_summary.get("workarounds", []))
+                result["notes"] = notes
+
+                results[config].append(result)
+
+    return results
+
+
+def aggregate_results(results: dict) -> dict:
+    """
+    Aggregate run results into summary statistics.
+
+    Returns run_summary with stats for each configuration and delta.
+    """
+    run_summary = {}
+    configs = list(results.keys())
+
+    for config in configs:
+        runs = results.get(config, [])
+
+        if not runs:
+            run_summary[config] = {
+                "pass_rate": {"mean": 0.0, "stddev": 0.0, "min": 0.0, "max": 0.0},
+                "time_seconds": {"mean": 0.0, "stddev": 0.0, "min": 0.0, "max": 0.0},
+                "tokens": {"mean": 0, "stddev": 0, "min": 0, "max": 0}
+            }
+            continue
+
+        pass_rates = [r["pass_rate"] for r in runs]
+        times = [r["time_seconds"] for r in runs]
+        tokens = [r.get("tokens", 0) for r in runs]
+
+        run_summary[config] = {
+            "pass_rate": calculate_stats(pass_rates),
+            "time_seconds": calculate_stats(times),
+            "tokens": calculate_stats(tokens)
+        }
+
+    # Calculate delta between the first two configs (if two exist)
+    if len(configs) >= 2:
+        primary = run_summary.get(configs[0], {})
+        baseline = run_summary.get(configs[1], {})
+    else:
+        primary = run_summary.get(configs[0], {}) if configs else {}
+        baseline = {}
+
+    delta_pass_rate = primary.get("pass_rate", {}).get("mean", 0) - baseline.get("pass_rate", {}).get("mean", 0)
+    delta_time = primary.get("time_seconds", {}).get("mean", 0) - baseline.get("time_seconds", {}).get("mean", 0)
+    delta_tokens = primary.get("tokens", {}).get("mean", 0) - baseline.get("tokens", {}).get("mean", 0)
+
+    run_summary["delta"] = {
+        "pass_rate": f"{delta_pass_rate:+.2f}",
+        "time_seconds": f"{delta_time:+.1f}",
+        "tokens": f"{delta_tokens:+.0f}"
+    }
+
+    return run_summary
+
+
+def generate_benchmark(benchmark_dir: Path, skill_name: str = "", skill_path: str = "") -> dict:
+    """
+    Generate complete benchmark.json from run results.
+    """
+    results = load_run_results(benchmark_dir)
+    run_summary = aggregate_results(results)
+
+    # Build runs array for benchmark.json
+    runs = []
+    for config in results:
+        for result in results[config]:
+            runs.append({
+                "eval_id": result["eval_id"],
+                "configuration": config,
+                "run_number": result["run_number"],
+                "result": {
+                    "pass_rate": result["pass_rate"],
+                    "passed": result["passed"],
+                    "failed": result["failed"],
+                    "total": result["total"],
+                    "time_seconds": result["time_seconds"],
+                    "tokens": result.get("tokens", 0),
+                    "tool_calls": result.get("tool_calls", 0),
+                    "errors": result.get("errors", 0)
+                },
+                "expectations": result["expectations"],
+                "notes": result["notes"]
+            })
+
+    # Determine eval IDs from results
+    eval_ids = sorted(set(
+        r["eval_id"]
+        for config in results.values()
+        for r in config
+    ))
+
+    benchmark = {
+        "metadata": {
+            "skill_name": skill_name or "<skill-name>",
+            "skill_path": skill_path or "<path/to/skill>",
+            "executor_model": "<model-name>",
+            "analyzer_model": "<model-name>",
+            "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "evals_run": eval_ids,
+            "runs_per_configuration": 3
+        },
+        "runs": runs,
+        "run_summary": run_summary,
+        "notes": []  # To be filled by analyzer
+    }
+
+    return benchmark
+
+
+def generate_markdown(benchmark: dict) -> str:
+    """Generate human-readable benchmark.md from benchmark data."""
+    metadata = benchmark["metadata"]
+    run_summary = benchmark["run_summary"]
+
+    # Determine config names (excluding "delta")
+    configs = [k for k in run_summary if k != "delta"]
+    config_a = configs[0] if len(configs) >= 1 else "config_a"
+    config_b = configs[1] if len(configs) >= 2 else "config_b"
+    label_a = config_a.replace("_", " ").title()
+    label_b = config_b.replace("_", " ").title()
+
+    lines = [
+        f"# Skill Benchmark: {metadata['skill_name']}",
+        "",
+        f"**Model**: {metadata['executor_model']}",
+        f"**Date**: {metadata['timestamp']}",
+        f"**Evals**: {', '.join(map(str, metadata['evals_run']))} ({metadata['runs_per_configuration']} runs each per configuration)",
+        "",
+        "## Summary",
+        "",
+        f"| Metric | {label_a} | {label_b} | Delta |",
+        "|--------|------------|---------------|-------|",
+    ]
+
+    a_summary = run_summary.get(config_a, {})
+    b_summary = run_summary.get(config_b, {})
+    delta = run_summary.get("delta", {})
+
+    # Format pass rate
+    a_pr = a_summary.get("pass_rate", {})
+    b_pr = b_summary.get("pass_rate", {})
+    lines.append(f"| Pass Rate | {a_pr.get('mean', 0)*100:.0f}% ± {a_pr.get('stddev', 0)*100:.0f}% | {b_pr.get('mean', 0)*100:.0f}% ± {b_pr.get('stddev', 0)*100:.0f}% | {delta.get('pass_rate', '—')} |")
+
+    # Format time
+    a_time = a_summary.get("time_seconds", {})
+    b_time = b_summary.get("time_seconds", {})
+    lines.append(f"| Time | {a_time.get('mean', 0):.1f}s ± {a_time.get('stddev', 0):.1f}s | {b_time.get('mean', 0):.1f}s ± {b_time.get('stddev', 0):.1f}s | {delta.get('time_seconds', '—')}s |")
+
+    # Format tokens
+    a_tokens = a_summary.get("tokens", {})
+    b_tokens = b_summary.get("tokens", {})
+    lines.append(f"| Tokens | {a_tokens.get('mean', 0):.0f} ± {a_tokens.get('stddev', 0):.0f} | {b_tokens.get('mean', 0):.0f} ± {b_tokens.get('stddev', 0):.0f} | {delta.get('tokens', '—')} |")
+
+    # Notes section
+    if benchmark.get("notes"):
+        lines.extend([
+            "",
+            "## Notes",
+            ""
+        ])
+        for note in benchmark["notes"]:
+            lines.append(f"- {note}")
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Aggregate benchmark run results into summary statistics"
+    )
+    parser.add_argument(
+        "benchmark_dir",
+        type=Path,
+        help="Path to the benchmark directory"
+    )
+    parser.add_argument(
+        "--skill-name",
+        default="",
+        help="Name of the skill being benchmarked"
+    )
+    parser.add_argument(
+        "--skill-path",
+        default="",
+        help="Path to the skill being benchmarked"
+    )
+    parser.add_argument(
+        "--output", "-o",
+        type=Path,
+        help="Output path for benchmark.json (default: <benchmark_dir>/benchmark.json)"
+    )
+
+    args = parser.parse_args()
+
+    if not args.benchmark_dir.exists():
+        print(f"Directory not found: {args.benchmark_dir}")
+        sys.exit(1)
+
+    # Generate benchmark
+    benchmark = generate_benchmark(args.benchmark_dir, args.skill_name, args.skill_path)
+
+    # Determine output paths
+    output_json = args.output or (args.benchmark_dir / "benchmark.json")
+    output_md = output_json.with_suffix(".md")
+
+    # Write benchmark.json
+    with open(output_json, "w") as f:
+        json.dump(benchmark, f, indent=2)
+    print(f"Generated: {output_json}")
+
+    # Write benchmark.md
+    markdown = generate_markdown(benchmark)
+    with open(output_md, "w") as f:
+        f.write(markdown)
+    print(f"Generated: {output_md}")
+
+    # Print summary
+    run_summary = benchmark["run_summary"]
+    configs = [k for k in run_summary if k != "delta"]
+    delta = run_summary.get("delta", {})
+
+    print(f"\nSummary:")
+    for config in configs:
+        pr = run_summary[config]["pass_rate"]["mean"]
+        label = config.replace("_", " ").title()
+        print(f"  {label}: {pr*100:.1f}% pass rate")
+    print(f"  Delta:         {delta.get('pass_rate', '—')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/skill-creator/scripts/generate_report.py
+++ b/.agents/skills/skill-creator/scripts/generate_report.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Generate an HTML report from run_loop.py output.
+
+Takes the JSON output from run_loop.py and generates a visual HTML report
+showing each description attempt with check/x for each test case.
+Distinguishes between train and test queries.
+"""
+
+import argparse
+import html
+import json
+import sys
+from pathlib import Path
+
+
+def generate_html(data: dict, auto_refresh: bool = False, skill_name: str = "") -> str:
+    """Generate HTML report from loop output data. If auto_refresh is True, adds a meta refresh tag."""
+    history = data.get("history", [])
+    holdout = data.get("holdout", 0)
+    title_prefix = html.escape(skill_name + " \u2014 ") if skill_name else ""
+
+    # Get all unique queries from train and test sets, with should_trigger info
+    train_queries: list[dict] = []
+    test_queries: list[dict] = []
+    if history:
+        for r in history[0].get("train_results", history[0].get("results", [])):
+            train_queries.append({"query": r["query"], "should_trigger": r.get("should_trigger", True)})
+        if history[0].get("test_results"):
+            for r in history[0].get("test_results", []):
+                test_queries.append({"query": r["query"], "should_trigger": r.get("should_trigger", True)})
+
+    refresh_tag = '    <meta http-equiv="refresh" content="5">\n' if auto_refresh else ""
+
+    html_parts = ["""<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+""" + refresh_tag + """    <title>""" + title_prefix + """Skill Description Optimization</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Lora', Georgia, serif;
+            max-width: 100%;
+            margin: 0 auto;
+            padding: 20px;
+            background: #faf9f5;
+            color: #141413;
+        }
+        h1 { font-family: 'Poppins', sans-serif; color: #141413; }
+        .explainer {
+            background: white;
+            padding: 15px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+            border: 1px solid #e8e6dc;
+            color: #b0aea5;
+            font-size: 0.875rem;
+            line-height: 1.6;
+        }
+        .summary {
+            background: white;
+            padding: 15px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+            border: 1px solid #e8e6dc;
+        }
+        .summary p { margin: 5px 0; }
+        .best { color: #788c5d; font-weight: bold; }
+        .table-container {
+            overflow-x: auto;
+            width: 100%;
+        }
+        table {
+            border-collapse: collapse;
+            background: white;
+            border: 1px solid #e8e6dc;
+            border-radius: 6px;
+            font-size: 12px;
+            min-width: 100%;
+        }
+        th, td {
+            padding: 8px;
+            text-align: left;
+            border: 1px solid #e8e6dc;
+            white-space: normal;
+            word-wrap: break-word;
+        }
+        th {
+            font-family: 'Poppins', sans-serif;
+            background: #141413;
+            color: #faf9f5;
+            font-weight: 500;
+        }
+        th.test-col {
+            background: #6a9bcc;
+        }
+        th.query-col { min-width: 200px; }
+        td.description {
+            font-family: monospace;
+            font-size: 11px;
+            word-wrap: break-word;
+            max-width: 400px;
+        }
+        td.result {
+            text-align: center;
+            font-size: 16px;
+            min-width: 40px;
+        }
+        td.test-result {
+            background: #f0f6fc;
+        }
+        .pass { color: #788c5d; }
+        .fail { color: #c44; }
+        .rate {
+            font-size: 9px;
+            color: #b0aea5;
+            display: block;
+        }
+        tr:hover { background: #faf9f5; }
+        .score {
+            display: inline-block;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-weight: bold;
+            font-size: 11px;
+        }
+        .score-good { background: #eef2e8; color: #788c5d; }
+        .score-ok { background: #fef3c7; color: #d97706; }
+        .score-bad { background: #fceaea; color: #c44; }
+        .train-label { color: #b0aea5; font-size: 10px; }
+        .test-label { color: #6a9bcc; font-size: 10px; font-weight: bold; }
+        .best-row { background: #f5f8f2; }
+        th.positive-col { border-bottom: 3px solid #788c5d; }
+        th.negative-col { border-bottom: 3px solid #c44; }
+        th.test-col.positive-col { border-bottom: 3px solid #788c5d; }
+        th.test-col.negative-col { border-bottom: 3px solid #c44; }
+        .legend { font-family: 'Poppins', sans-serif; display: flex; gap: 20px; margin-bottom: 10px; font-size: 13px; align-items: center; }
+        .legend-item { display: flex; align-items: center; gap: 6px; }
+        .legend-swatch { width: 16px; height: 16px; border-radius: 3px; display: inline-block; }
+        .swatch-positive { background: #141413; border-bottom: 3px solid #788c5d; }
+        .swatch-negative { background: #141413; border-bottom: 3px solid #c44; }
+        .swatch-test { background: #6a9bcc; }
+        .swatch-train { background: #141413; }
+    </style>
+</head>
+<body>
+    <h1>""" + title_prefix + """Skill Description Optimization</h1>
+    <div class="explainer">
+        <strong>Optimizing your skill's description.</strong> This page updates automatically as Claude tests different versions of your skill's description. Each row is an iteration — a new description attempt. The columns show test queries: green checkmarks mean the skill triggered correctly (or correctly didn't trigger), red crosses mean it got it wrong. The "Train" score shows performance on queries used to improve the description; the "Test" score shows performance on held-out queries the optimizer hasn't seen. When it's done, Claude will apply the best-performing description to your skill.
+    </div>
+"""]
+
+    # Summary section
+    best_test_score = data.get('best_test_score')
+    best_train_score = data.get('best_train_score')
+    html_parts.append(f"""
+    <div class="summary">
+        <p><strong>Original:</strong> {html.escape(data.get('original_description', 'N/A'))}</p>
+        <p class="best"><strong>Best:</strong> {html.escape(data.get('best_description', 'N/A'))}</p>
+        <p><strong>Best Score:</strong> {data.get('best_score', 'N/A')} {'(test)' if best_test_score else '(train)'}</p>
+        <p><strong>Iterations:</strong> {data.get('iterations_run', 0)} | <strong>Train:</strong> {data.get('train_size', '?')} | <strong>Test:</strong> {data.get('test_size', '?')}</p>
+    </div>
+""")
+
+    # Legend
+    html_parts.append("""
+    <div class="legend">
+        <span style="font-weight:600">Query columns:</span>
+        <span class="legend-item"><span class="legend-swatch swatch-positive"></span> Should trigger</span>
+        <span class="legend-item"><span class="legend-swatch swatch-negative"></span> Should NOT trigger</span>
+        <span class="legend-item"><span class="legend-swatch swatch-train"></span> Train</span>
+        <span class="legend-item"><span class="legend-swatch swatch-test"></span> Test</span>
+    </div>
+""")
+
+    # Table header
+    html_parts.append("""
+    <div class="table-container">
+    <table>
+        <thead>
+            <tr>
+                <th>Iter</th>
+                <th>Train</th>
+                <th>Test</th>
+                <th class="query-col">Description</th>
+""")
+
+    # Add column headers for train queries
+    for qinfo in train_queries:
+        polarity = "positive-col" if qinfo["should_trigger"] else "negative-col"
+        html_parts.append(f'                <th class="{polarity}">{html.escape(qinfo["query"])}</th>\n')
+
+    # Add column headers for test queries (different color)
+    for qinfo in test_queries:
+        polarity = "positive-col" if qinfo["should_trigger"] else "negative-col"
+        html_parts.append(f'                <th class="test-col {polarity}">{html.escape(qinfo["query"])}</th>\n')
+
+    html_parts.append("""            </tr>
+        </thead>
+        <tbody>
+""")
+
+    # Find best iteration for highlighting
+    if test_queries:
+        best_iter = max(history, key=lambda h: h.get("test_passed") or 0).get("iteration")
+    else:
+        best_iter = max(history, key=lambda h: h.get("train_passed", h.get("passed", 0))).get("iteration")
+
+    # Add rows for each iteration
+    for h in history:
+        iteration = h.get("iteration", "?")
+        train_passed = h.get("train_passed", h.get("passed", 0))
+        train_total = h.get("train_total", h.get("total", 0))
+        test_passed = h.get("test_passed")
+        test_total = h.get("test_total")
+        description = h.get("description", "")
+        train_results = h.get("train_results", h.get("results", []))
+        test_results = h.get("test_results", [])
+
+        # Create lookups for results by query
+        train_by_query = {r["query"]: r for r in train_results}
+        test_by_query = {r["query"]: r for r in test_results} if test_results else {}
+
+        # Compute aggregate correct/total runs across all retries
+        def aggregate_runs(results: list[dict]) -> tuple[int, int]:
+            correct = 0
+            total = 0
+            for r in results:
+                runs = r.get("runs", 0)
+                triggers = r.get("triggers", 0)
+                total += runs
+                if r.get("should_trigger", True):
+                    correct += triggers
+                else:
+                    correct += runs - triggers
+            return correct, total
+
+        train_correct, train_runs = aggregate_runs(train_results)
+        test_correct, test_runs = aggregate_runs(test_results)
+
+        # Determine score classes
+        def score_class(correct: int, total: int) -> str:
+            if total > 0:
+                ratio = correct / total
+                if ratio >= 0.8:
+                    return "score-good"
+                elif ratio >= 0.5:
+                    return "score-ok"
+            return "score-bad"
+
+        train_class = score_class(train_correct, train_runs)
+        test_class = score_class(test_correct, test_runs)
+
+        row_class = "best-row" if iteration == best_iter else ""
+
+        html_parts.append(f"""            <tr class="{row_class}">
+                <td>{iteration}</td>
+                <td><span class="score {train_class}">{train_correct}/{train_runs}</span></td>
+                <td><span class="score {test_class}">{test_correct}/{test_runs}</span></td>
+                <td class="description">{html.escape(description)}</td>
+""")
+
+        # Add result for each train query
+        for qinfo in train_queries:
+            r = train_by_query.get(qinfo["query"], {})
+            did_pass = r.get("pass", False)
+            triggers = r.get("triggers", 0)
+            runs = r.get("runs", 0)
+
+            icon = "✓" if did_pass else "✗"
+            css_class = "pass" if did_pass else "fail"
+
+            html_parts.append(f'                <td class="result {css_class}">{icon}<span class="rate">{triggers}/{runs}</span></td>\n')
+
+        # Add result for each test query (with different background)
+        for qinfo in test_queries:
+            r = test_by_query.get(qinfo["query"], {})
+            did_pass = r.get("pass", False)
+            triggers = r.get("triggers", 0)
+            runs = r.get("runs", 0)
+
+            icon = "✓" if did_pass else "✗"
+            css_class = "pass" if did_pass else "fail"
+
+            html_parts.append(f'                <td class="result test-result {css_class}">{icon}<span class="rate">{triggers}/{runs}</span></td>\n')
+
+        html_parts.append("            </tr>\n")
+
+    html_parts.append("""        </tbody>
+    </table>
+    </div>
+""")
+
+    html_parts.append("""
+</body>
+</html>
+""")
+
+    return "".join(html_parts)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate HTML report from run_loop output")
+    parser.add_argument("input", help="Path to JSON output from run_loop.py (or - for stdin)")
+    parser.add_argument("-o", "--output", default=None, help="Output HTML file (default: stdout)")
+    parser.add_argument("--skill-name", default="", help="Skill name to include in the report title")
+    args = parser.parse_args()
+
+    if args.input == "-":
+        data = json.load(sys.stdin)
+    else:
+        data = json.loads(Path(args.input).read_text())
+
+    html_output = generate_html(data, skill_name=args.skill_name)
+
+    if args.output:
+        Path(args.output).write_text(html_output)
+        print(f"Report written to {args.output}", file=sys.stderr)
+    else:
+        print(html_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/skill-creator/scripts/improve_description.py
+++ b/.agents/skills/skill-creator/scripts/improve_description.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Improve a skill description based on eval results.
+
+Takes eval results (from run_eval.py) and generates an improved description
+by calling `claude -p` as a subprocess (same auth pattern as run_eval.py —
+uses the session's Claude Code auth, no separate ANTHROPIC_API_KEY needed).
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.utils import parse_skill_md
+
+
+def _call_claude(prompt: str, model: str | None, timeout: int = 300) -> str:
+    """Run `claude -p` with the prompt on stdin and return the text response.
+
+    Prompt goes over stdin (not argv) because it embeds the full SKILL.md
+    body and can easily exceed comfortable argv length.
+    """
+    cmd = ["claude", "-p", "--output-format", "text"]
+    if model:
+        cmd.extend(["--model", model])
+
+    # Remove CLAUDECODE env var to allow nesting claude -p inside a
+    # Claude Code session. The guard is for interactive terminal conflicts;
+    # programmatic subprocess usage is safe. Same pattern as run_eval.py.
+    env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+    result = subprocess.run(
+        cmd,
+        input=prompt,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"claude -p exited {result.returncode}\nstderr: {result.stderr}"
+        )
+    return result.stdout
+
+
+def improve_description(
+    skill_name: str,
+    skill_content: str,
+    current_description: str,
+    eval_results: dict,
+    history: list[dict],
+    model: str,
+    test_results: dict | None = None,
+    log_dir: Path | None = None,
+    iteration: int | None = None,
+) -> str:
+    """Call Claude to improve the description based on eval results."""
+    failed_triggers = [
+        r for r in eval_results["results"]
+        if r["should_trigger"] and not r["pass"]
+    ]
+    false_triggers = [
+        r for r in eval_results["results"]
+        if not r["should_trigger"] and not r["pass"]
+    ]
+
+    # Build scores summary
+    train_score = f"{eval_results['summary']['passed']}/{eval_results['summary']['total']}"
+    if test_results:
+        test_score = f"{test_results['summary']['passed']}/{test_results['summary']['total']}"
+        scores_summary = f"Train: {train_score}, Test: {test_score}"
+    else:
+        scores_summary = f"Train: {train_score}"
+
+    prompt = f"""You are optimizing a skill description for a Claude Code skill called "{skill_name}". A "skill" is sort of like a prompt, but with progressive disclosure -- there's a title and description that Claude sees when deciding whether to use the skill, and then if it does use the skill, it reads the .md file which has lots more details and potentially links to other resources in the skill folder like helper files and scripts and additional documentation or examples.
+
+The description appears in Claude's "available_skills" list. When a user sends a query, Claude decides whether to invoke the skill based solely on the title and on this description. Your goal is to write a description that triggers for relevant queries, and doesn't trigger for irrelevant ones.
+
+Here's the current description:
+<current_description>
+"{current_description}"
+</current_description>
+
+Current scores ({scores_summary}):
+<scores_summary>
+"""
+    if failed_triggers:
+        prompt += "FAILED TO TRIGGER (should have triggered but didn't):\n"
+        for r in failed_triggers:
+            prompt += f'  - "{r["query"]}" (triggered {r["triggers"]}/{r["runs"]} times)\n'
+        prompt += "\n"
+
+    if false_triggers:
+        prompt += "FALSE TRIGGERS (triggered but shouldn't have):\n"
+        for r in false_triggers:
+            prompt += f'  - "{r["query"]}" (triggered {r["triggers"]}/{r["runs"]} times)\n'
+        prompt += "\n"
+
+    if history:
+        prompt += "PREVIOUS ATTEMPTS (do NOT repeat these — try something structurally different):\n\n"
+        for h in history:
+            train_s = f"{h.get('train_passed', h.get('passed', 0))}/{h.get('train_total', h.get('total', 0))}"
+            test_s = f"{h.get('test_passed', '?')}/{h.get('test_total', '?')}" if h.get('test_passed') is not None else None
+            score_str = f"train={train_s}" + (f", test={test_s}" if test_s else "")
+            prompt += f'<attempt {score_str}>\n'
+            prompt += f'Description: "{h["description"]}"\n'
+            if "results" in h:
+                prompt += "Train results:\n"
+                for r in h["results"]:
+                    status = "PASS" if r["pass"] else "FAIL"
+                    prompt += f'  [{status}] "{r["query"][:80]}" (triggered {r["triggers"]}/{r["runs"]})\n'
+            if h.get("note"):
+                prompt += f'Note: {h["note"]}\n'
+            prompt += "</attempt>\n\n"
+
+    prompt += f"""</scores_summary>
+
+Skill content (for context on what the skill does):
+<skill_content>
+{skill_content}
+</skill_content>
+
+Based on the failures, write a new and improved description that is more likely to trigger correctly. When I say "based on the failures", it's a bit of a tricky line to walk because we don't want to overfit to the specific cases you're seeing. So what I DON'T want you to do is produce an ever-expanding list of specific queries that this skill should or shouldn't trigger for. Instead, try to generalize from the failures to broader categories of user intent and situations where this skill would be useful or not useful. The reason for this is twofold:
+
+1. Avoid overfitting
+2. The list might get loooong and it's injected into ALL queries and there might be a lot of skills, so we don't want to blow too much space on any given description.
+
+Concretely, your description should not be more than about 100-200 words, even if that comes at the cost of accuracy. There is a hard limit of 1024 characters — descriptions over that will be truncated, so stay comfortably under it.
+
+Here are some tips that we've found to work well in writing these descriptions:
+- The skill should be phrased in the imperative -- "Use this skill for" rather than "this skill does"
+- The skill description should focus on the user's intent, what they are trying to achieve, vs. the implementation details of how the skill works.
+- The description competes with other skills for Claude's attention — make it distinctive and immediately recognizable.
+- If you're getting lots of failures after repeated attempts, change things up. Try different sentence structures or wordings.
+
+I'd encourage you to be creative and mix up the style in different iterations since you'll have multiple opportunities to try different approaches and we'll just grab the highest-scoring one at the end. 
+
+Please respond with only the new description text in <new_description> tags, nothing else."""
+
+    text = _call_claude(prompt, model)
+
+    match = re.search(r"<new_description>(.*?)</new_description>", text, re.DOTALL)
+    description = match.group(1).strip().strip('"') if match else text.strip().strip('"')
+
+    transcript: dict = {
+        "iteration": iteration,
+        "prompt": prompt,
+        "response": text,
+        "parsed_description": description,
+        "char_count": len(description),
+        "over_limit": len(description) > 1024,
+    }
+
+    # Safety net: the prompt already states the 1024-char hard limit, but if
+    # the model blew past it anyway, make one fresh single-turn call that
+    # quotes the too-long version and asks for a shorter rewrite. (The old
+    # SDK path did this as a true multi-turn; `claude -p` is one-shot, so we
+    # inline the prior output into the new prompt instead.)
+    if len(description) > 1024:
+        shorten_prompt = (
+            f"{prompt}\n\n"
+            f"---\n\n"
+            f"A previous attempt produced this description, which at "
+            f"{len(description)} characters is over the 1024-character hard limit:\n\n"
+            f'"{description}"\n\n'
+            f"Rewrite it to be under 1024 characters while keeping the most "
+            f"important trigger words and intent coverage. Respond with only "
+            f"the new description in <new_description> tags."
+        )
+        shorten_text = _call_claude(shorten_prompt, model)
+        match = re.search(r"<new_description>(.*?)</new_description>", shorten_text, re.DOTALL)
+        shortened = match.group(1).strip().strip('"') if match else shorten_text.strip().strip('"')
+
+        transcript["rewrite_prompt"] = shorten_prompt
+        transcript["rewrite_response"] = shorten_text
+        transcript["rewrite_description"] = shortened
+        transcript["rewrite_char_count"] = len(shortened)
+        description = shortened
+
+    transcript["final_description"] = description
+
+    if log_dir:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_file = log_dir / f"improve_iter_{iteration or 'unknown'}.json"
+        log_file.write_text(json.dumps(transcript, indent=2))
+
+    return description
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Improve a skill description based on eval results")
+    parser.add_argument("--eval-results", required=True, help="Path to eval results JSON (from run_eval.py)")
+    parser.add_argument("--skill-path", required=True, help="Path to skill directory")
+    parser.add_argument("--history", default=None, help="Path to history JSON (previous attempts)")
+    parser.add_argument("--model", required=True, help="Model for improvement")
+    parser.add_argument("--verbose", action="store_true", help="Print thinking to stderr")
+    args = parser.parse_args()
+
+    skill_path = Path(args.skill_path)
+    if not (skill_path / "SKILL.md").exists():
+        print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
+        sys.exit(1)
+
+    eval_results = json.loads(Path(args.eval_results).read_text())
+    history = []
+    if args.history:
+        history = json.loads(Path(args.history).read_text())
+
+    name, _, content = parse_skill_md(skill_path)
+    current_description = eval_results["description"]
+
+    if args.verbose:
+        print(f"Current: {current_description}", file=sys.stderr)
+        print(f"Score: {eval_results['summary']['passed']}/{eval_results['summary']['total']}", file=sys.stderr)
+
+    new_description = improve_description(
+        skill_name=name,
+        skill_content=content,
+        current_description=current_description,
+        eval_results=eval_results,
+        history=history,
+        model=args.model,
+    )
+
+    if args.verbose:
+        print(f"Improved: {new_description}", file=sys.stderr)
+
+    # Output as JSON with both the new description and updated history
+    output = {
+        "description": new_description,
+        "history": history + [{
+            "description": current_description,
+            "passed": eval_results["summary"]["passed"],
+            "failed": eval_results["summary"]["failed"],
+            "total": eval_results["summary"]["total"],
+            "results": eval_results["results"],
+        }],
+    }
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/skill-creator/scripts/package_skill.py
+++ b/.agents/skills/skill-creator/scripts/package_skill.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+Skill Packager - Creates a distributable .skill file of a skill folder
+
+Usage:
+    python utils/package_skill.py <path/to/skill-folder> [output-directory]
+
+Example:
+    python utils/package_skill.py skills/public/my-skill
+    python utils/package_skill.py skills/public/my-skill ./dist
+"""
+
+import fnmatch
+import sys
+import zipfile
+from pathlib import Path
+from scripts.quick_validate import validate_skill
+
+# Patterns to exclude when packaging skills.
+EXCLUDE_DIRS = {"__pycache__", "node_modules"}
+EXCLUDE_GLOBS = {"*.pyc"}
+EXCLUDE_FILES = {".DS_Store"}
+# Directories excluded only at the skill root (not when nested deeper).
+ROOT_EXCLUDE_DIRS = {"evals"}
+
+
+def should_exclude(rel_path: Path) -> bool:
+    """Check if a path should be excluded from packaging."""
+    parts = rel_path.parts
+    if any(part in EXCLUDE_DIRS for part in parts):
+        return True
+    # rel_path is relative to skill_path.parent, so parts[0] is the skill
+    # folder name and parts[1] (if present) is the first subdir.
+    if len(parts) > 1 and parts[1] in ROOT_EXCLUDE_DIRS:
+        return True
+    name = rel_path.name
+    if name in EXCLUDE_FILES:
+        return True
+    return any(fnmatch.fnmatch(name, pat) for pat in EXCLUDE_GLOBS)
+
+
+def package_skill(skill_path, output_dir=None):
+    """
+    Package a skill folder into a .skill file.
+
+    Args:
+        skill_path: Path to the skill folder
+        output_dir: Optional output directory for the .skill file (defaults to current directory)
+
+    Returns:
+        Path to the created .skill file, or None if error
+    """
+    skill_path = Path(skill_path).resolve()
+
+    # Validate skill folder exists
+    if not skill_path.exists():
+        print(f"❌ Error: Skill folder not found: {skill_path}")
+        return None
+
+    if not skill_path.is_dir():
+        print(f"❌ Error: Path is not a directory: {skill_path}")
+        return None
+
+    # Validate SKILL.md exists
+    skill_md = skill_path / "SKILL.md"
+    if not skill_md.exists():
+        print(f"❌ Error: SKILL.md not found in {skill_path}")
+        return None
+
+    # Run validation before packaging
+    print("🔍 Validating skill...")
+    valid, message = validate_skill(skill_path)
+    if not valid:
+        print(f"❌ Validation failed: {message}")
+        print("   Please fix the validation errors before packaging.")
+        return None
+    print(f"✅ {message}\n")
+
+    # Determine output location
+    skill_name = skill_path.name
+    if output_dir:
+        output_path = Path(output_dir).resolve()
+        output_path.mkdir(parents=True, exist_ok=True)
+    else:
+        output_path = Path.cwd()
+
+    skill_filename = output_path / f"{skill_name}.skill"
+
+    # Create the .skill file (zip format)
+    try:
+        with zipfile.ZipFile(skill_filename, 'w', zipfile.ZIP_DEFLATED) as zipf:
+            # Walk through the skill directory, excluding build artifacts
+            for file_path in skill_path.rglob('*'):
+                if not file_path.is_file():
+                    continue
+                arcname = file_path.relative_to(skill_path.parent)
+                if should_exclude(arcname):
+                    print(f"  Skipped: {arcname}")
+                    continue
+                zipf.write(file_path, arcname)
+                print(f"  Added: {arcname}")
+
+        print(f"\n✅ Successfully packaged skill to: {skill_filename}")
+        return skill_filename
+
+    except Exception as e:
+        print(f"❌ Error creating .skill file: {e}")
+        return None
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python utils/package_skill.py <path/to/skill-folder> [output-directory]")
+        print("\nExample:")
+        print("  python utils/package_skill.py skills/public/my-skill")
+        print("  python utils/package_skill.py skills/public/my-skill ./dist")
+        sys.exit(1)
+
+    skill_path = sys.argv[1]
+    output_dir = sys.argv[2] if len(sys.argv) > 2 else None
+
+    print(f"📦 Packaging skill: {skill_path}")
+    if output_dir:
+        print(f"   Output directory: {output_dir}")
+    print()
+
+    result = package_skill(skill_path, output_dir)
+
+    if result:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/skill-creator/scripts/quick_validate.py
+++ b/.agents/skills/skill-creator/scripts/quick_validate.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Quick validation script for skills - minimal version
+"""
+
+import sys
+import os
+import re
+import yaml
+from pathlib import Path
+
+def validate_skill(skill_path):
+    """Basic validation of a skill"""
+    skill_path = Path(skill_path)
+
+    # Check SKILL.md exists
+    skill_md = skill_path / 'SKILL.md'
+    if not skill_md.exists():
+        return False, "SKILL.md not found"
+
+    # Read and validate frontmatter
+    content = skill_md.read_text()
+    if not content.startswith('---'):
+        return False, "No YAML frontmatter found"
+
+    # Extract frontmatter
+    match = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
+    if not match:
+        return False, "Invalid frontmatter format"
+
+    frontmatter_text = match.group(1)
+
+    # Parse YAML frontmatter
+    try:
+        frontmatter = yaml.safe_load(frontmatter_text)
+        if not isinstance(frontmatter, dict):
+            return False, "Frontmatter must be a YAML dictionary"
+    except yaml.YAMLError as e:
+        return False, f"Invalid YAML in frontmatter: {e}"
+
+    # Define allowed properties
+    ALLOWED_PROPERTIES = {'name', 'description', 'license', 'allowed-tools', 'metadata', 'compatibility'}
+
+    # Check for unexpected properties (excluding nested keys under metadata)
+    unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES
+    if unexpected_keys:
+        return False, (
+            f"Unexpected key(s) in SKILL.md frontmatter: {', '.join(sorted(unexpected_keys))}. "
+            f"Allowed properties are: {', '.join(sorted(ALLOWED_PROPERTIES))}"
+        )
+
+    # Check required fields
+    if 'name' not in frontmatter:
+        return False, "Missing 'name' in frontmatter"
+    if 'description' not in frontmatter:
+        return False, "Missing 'description' in frontmatter"
+
+    # Extract name for validation
+    name = frontmatter.get('name', '')
+    if not isinstance(name, str):
+        return False, f"Name must be a string, got {type(name).__name__}"
+    name = name.strip()
+    if name:
+        # Check naming convention (kebab-case: lowercase with hyphens)
+        if not re.match(r'^[a-z0-9-]+$', name):
+            return False, f"Name '{name}' should be kebab-case (lowercase letters, digits, and hyphens only)"
+        if name.startswith('-') or name.endswith('-') or '--' in name:
+            return False, f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens"
+        # Check name length (max 64 characters per spec)
+        if len(name) > 64:
+            return False, f"Name is too long ({len(name)} characters). Maximum is 64 characters."
+
+    # Extract and validate description
+    description = frontmatter.get('description', '')
+    if not isinstance(description, str):
+        return False, f"Description must be a string, got {type(description).__name__}"
+    description = description.strip()
+    if description:
+        # Check for angle brackets
+        if '<' in description or '>' in description:
+            return False, "Description cannot contain angle brackets (< or >)"
+        # Check description length (max 1024 characters per spec)
+        if len(description) > 1024:
+            return False, f"Description is too long ({len(description)} characters). Maximum is 1024 characters."
+
+    # Validate compatibility field if present (optional)
+    compatibility = frontmatter.get('compatibility', '')
+    if compatibility:
+        if not isinstance(compatibility, str):
+            return False, f"Compatibility must be a string, got {type(compatibility).__name__}"
+        if len(compatibility) > 500:
+            return False, f"Compatibility is too long ({len(compatibility)} characters). Maximum is 500 characters."
+
+    return True, "Skill is valid!"
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python quick_validate.py <skill_directory>")
+        sys.exit(1)
+    
+    valid, message = validate_skill(sys.argv[1])
+    print(message)
+    sys.exit(0 if valid else 1)

--- a/.agents/skills/skill-creator/scripts/run_eval.py
+++ b/.agents/skills/skill-creator/scripts/run_eval.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Run trigger evaluation for a skill description.
+
+Tests whether a skill's description causes Claude to trigger (read the skill)
+for a set of queries. Outputs results as JSON.
+"""
+
+import argparse
+import json
+import os
+import select
+import subprocess
+import sys
+import time
+import uuid
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+from scripts.utils import parse_skill_md
+
+
+def find_project_root() -> Path:
+    """Find the project root by walking up from cwd looking for .claude/.
+
+    Mimics how Claude Code discovers its project root, so the command file
+    we create ends up where claude -p will look for it.
+    """
+    current = Path.cwd()
+    for parent in [current, *current.parents]:
+        if (parent / ".claude").is_dir():
+            return parent
+    return current
+
+
+def run_single_query(
+    query: str,
+    skill_name: str,
+    skill_description: str,
+    timeout: int,
+    project_root: str,
+    model: str | None = None,
+) -> bool:
+    """Run a single query and return whether the skill was triggered.
+
+    Creates a command file in .claude/commands/ so it appears in Claude's
+    available_skills list, then runs `claude -p` with the raw query.
+    Uses --include-partial-messages to detect triggering early from
+    stream events (content_block_start) rather than waiting for the
+    full assistant message, which only arrives after tool execution.
+    """
+    unique_id = uuid.uuid4().hex[:8]
+    clean_name = f"{skill_name}-skill-{unique_id}"
+    project_commands_dir = Path(project_root) / ".claude" / "commands"
+    command_file = project_commands_dir / f"{clean_name}.md"
+
+    try:
+        project_commands_dir.mkdir(parents=True, exist_ok=True)
+        # Use YAML block scalar to avoid breaking on quotes in description
+        indented_desc = "\n  ".join(skill_description.split("\n"))
+        command_content = (
+            f"---\n"
+            f"description: |\n"
+            f"  {indented_desc}\n"
+            f"---\n\n"
+            f"# {skill_name}\n\n"
+            f"This skill handles: {skill_description}\n"
+        )
+        command_file.write_text(command_content)
+
+        cmd = [
+            "claude",
+            "-p", query,
+            "--output-format", "stream-json",
+            "--verbose",
+            "--include-partial-messages",
+        ]
+        if model:
+            cmd.extend(["--model", model])
+
+        # Remove CLAUDECODE env var to allow nesting claude -p inside a
+        # Claude Code session. The guard is for interactive terminal conflicts;
+        # programmatic subprocess usage is safe.
+        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            cwd=project_root,
+            env=env,
+        )
+
+        triggered = False
+        start_time = time.time()
+        buffer = ""
+        # Track state for stream event detection
+        pending_tool_name = None
+        accumulated_json = ""
+
+        try:
+            while time.time() - start_time < timeout:
+                if process.poll() is not None:
+                    remaining = process.stdout.read()
+                    if remaining:
+                        buffer += remaining.decode("utf-8", errors="replace")
+                    break
+
+                ready, _, _ = select.select([process.stdout], [], [], 1.0)
+                if not ready:
+                    continue
+
+                chunk = os.read(process.stdout.fileno(), 8192)
+                if not chunk:
+                    break
+                buffer += chunk.decode("utf-8", errors="replace")
+
+                while "\n" in buffer:
+                    line, buffer = buffer.split("\n", 1)
+                    line = line.strip()
+                    if not line:
+                        continue
+
+                    try:
+                        event = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+
+                    # Early detection via stream events
+                    if event.get("type") == "stream_event":
+                        se = event.get("event", {})
+                        se_type = se.get("type", "")
+
+                        if se_type == "content_block_start":
+                            cb = se.get("content_block", {})
+                            if cb.get("type") == "tool_use":
+                                tool_name = cb.get("name", "")
+                                if tool_name in ("Skill", "Read"):
+                                    pending_tool_name = tool_name
+                                    accumulated_json = ""
+                                else:
+                                    return False
+
+                        elif se_type == "content_block_delta" and pending_tool_name:
+                            delta = se.get("delta", {})
+                            if delta.get("type") == "input_json_delta":
+                                accumulated_json += delta.get("partial_json", "")
+                                if clean_name in accumulated_json:
+                                    return True
+
+                        elif se_type in ("content_block_stop", "message_stop"):
+                            if pending_tool_name:
+                                return clean_name in accumulated_json
+                            if se_type == "message_stop":
+                                return False
+
+                    # Fallback: full assistant message
+                    elif event.get("type") == "assistant":
+                        message = event.get("message", {})
+                        for content_item in message.get("content", []):
+                            if content_item.get("type") != "tool_use":
+                                continue
+                            tool_name = content_item.get("name", "")
+                            tool_input = content_item.get("input", {})
+                            if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
+                                triggered = True
+                            elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
+                                triggered = True
+                            return triggered
+
+                    elif event.get("type") == "result":
+                        return triggered
+        finally:
+            # Clean up process on any exit path (return, exception, timeout)
+            if process.poll() is None:
+                process.kill()
+                process.wait()
+
+        return triggered
+    finally:
+        if command_file.exists():
+            command_file.unlink()
+
+
+def run_eval(
+    eval_set: list[dict],
+    skill_name: str,
+    description: str,
+    num_workers: int,
+    timeout: int,
+    project_root: Path,
+    runs_per_query: int = 1,
+    trigger_threshold: float = 0.5,
+    model: str | None = None,
+) -> dict:
+    """Run the full eval set and return results."""
+    results = []
+
+    with ProcessPoolExecutor(max_workers=num_workers) as executor:
+        future_to_info = {}
+        for item in eval_set:
+            for run_idx in range(runs_per_query):
+                future = executor.submit(
+                    run_single_query,
+                    item["query"],
+                    skill_name,
+                    description,
+                    timeout,
+                    str(project_root),
+                    model,
+                )
+                future_to_info[future] = (item, run_idx)
+
+        query_triggers: dict[str, list[bool]] = {}
+        query_items: dict[str, dict] = {}
+        for future in as_completed(future_to_info):
+            item, _ = future_to_info[future]
+            query = item["query"]
+            query_items[query] = item
+            if query not in query_triggers:
+                query_triggers[query] = []
+            try:
+                query_triggers[query].append(future.result())
+            except Exception as e:
+                print(f"Warning: query failed: {e}", file=sys.stderr)
+                query_triggers[query].append(False)
+
+    for query, triggers in query_triggers.items():
+        item = query_items[query]
+        trigger_rate = sum(triggers) / len(triggers)
+        should_trigger = item["should_trigger"]
+        if should_trigger:
+            did_pass = trigger_rate >= trigger_threshold
+        else:
+            did_pass = trigger_rate < trigger_threshold
+        results.append({
+            "query": query,
+            "should_trigger": should_trigger,
+            "trigger_rate": trigger_rate,
+            "triggers": sum(triggers),
+            "runs": len(triggers),
+            "pass": did_pass,
+        })
+
+    passed = sum(1 for r in results if r["pass"])
+    total = len(results)
+
+    return {
+        "skill_name": skill_name,
+        "description": description,
+        "results": results,
+        "summary": {
+            "total": total,
+            "passed": passed,
+            "failed": total - passed,
+        },
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run trigger evaluation for a skill description")
+    parser.add_argument("--eval-set", required=True, help="Path to eval set JSON file")
+    parser.add_argument("--skill-path", required=True, help="Path to skill directory")
+    parser.add_argument("--description", default=None, help="Override description to test")
+    parser.add_argument("--num-workers", type=int, default=10, help="Number of parallel workers")
+    parser.add_argument("--timeout", type=int, default=30, help="Timeout per query in seconds")
+    parser.add_argument("--runs-per-query", type=int, default=3, help="Number of runs per query")
+    parser.add_argument("--trigger-threshold", type=float, default=0.5, help="Trigger rate threshold")
+    parser.add_argument("--model", default=None, help="Model to use for claude -p (default: user's configured model)")
+    parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
+    args = parser.parse_args()
+
+    eval_set = json.loads(Path(args.eval_set).read_text())
+    skill_path = Path(args.skill_path)
+
+    if not (skill_path / "SKILL.md").exists():
+        print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
+        sys.exit(1)
+
+    name, original_description, content = parse_skill_md(skill_path)
+    description = args.description or original_description
+    project_root = find_project_root()
+
+    if args.verbose:
+        print(f"Evaluating: {description}", file=sys.stderr)
+
+    output = run_eval(
+        eval_set=eval_set,
+        skill_name=name,
+        description=description,
+        num_workers=args.num_workers,
+        timeout=args.timeout,
+        project_root=project_root,
+        runs_per_query=args.runs_per_query,
+        trigger_threshold=args.trigger_threshold,
+        model=args.model,
+    )
+
+    if args.verbose:
+        summary = output["summary"]
+        print(f"Results: {summary['passed']}/{summary['total']} passed", file=sys.stderr)
+        for r in output["results"]:
+            status = "PASS" if r["pass"] else "FAIL"
+            rate_str = f"{r['triggers']}/{r['runs']}"
+            print(f"  [{status}] rate={rate_str} expected={r['should_trigger']}: {r['query'][:70]}", file=sys.stderr)
+
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/skill-creator/scripts/run_loop.py
+++ b/.agents/skills/skill-creator/scripts/run_loop.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Run the eval + improve loop until all pass or max iterations reached.
+
+Combines run_eval.py and improve_description.py in a loop, tracking history
+and returning the best description found. Supports train/test split to prevent
+overfitting.
+"""
+
+import argparse
+import json
+import random
+import sys
+import tempfile
+import time
+import webbrowser
+from pathlib import Path
+
+from scripts.generate_report import generate_html
+from scripts.improve_description import improve_description
+from scripts.run_eval import find_project_root, run_eval
+from scripts.utils import parse_skill_md
+
+
+def split_eval_set(eval_set: list[dict], holdout: float, seed: int = 42) -> tuple[list[dict], list[dict]]:
+    """Split eval set into train and test sets, stratified by should_trigger."""
+    random.seed(seed)
+
+    # Separate by should_trigger
+    trigger = [e for e in eval_set if e["should_trigger"]]
+    no_trigger = [e for e in eval_set if not e["should_trigger"]]
+
+    # Shuffle each group
+    random.shuffle(trigger)
+    random.shuffle(no_trigger)
+
+    # Calculate split points
+    n_trigger_test = max(1, int(len(trigger) * holdout))
+    n_no_trigger_test = max(1, int(len(no_trigger) * holdout))
+
+    # Split
+    test_set = trigger[:n_trigger_test] + no_trigger[:n_no_trigger_test]
+    train_set = trigger[n_trigger_test:] + no_trigger[n_no_trigger_test:]
+
+    return train_set, test_set
+
+
+def run_loop(
+    eval_set: list[dict],
+    skill_path: Path,
+    description_override: str | None,
+    num_workers: int,
+    timeout: int,
+    max_iterations: int,
+    runs_per_query: int,
+    trigger_threshold: float,
+    holdout: float,
+    model: str,
+    verbose: bool,
+    live_report_path: Path | None = None,
+    log_dir: Path | None = None,
+) -> dict:
+    """Run the eval + improvement loop."""
+    project_root = find_project_root()
+    name, original_description, content = parse_skill_md(skill_path)
+    current_description = description_override or original_description
+
+    # Split into train/test if holdout > 0
+    if holdout > 0:
+        train_set, test_set = split_eval_set(eval_set, holdout)
+        if verbose:
+            print(f"Split: {len(train_set)} train, {len(test_set)} test (holdout={holdout})", file=sys.stderr)
+    else:
+        train_set = eval_set
+        test_set = []
+
+    history = []
+    exit_reason = "unknown"
+
+    for iteration in range(1, max_iterations + 1):
+        if verbose:
+            print(f"\n{'='*60}", file=sys.stderr)
+            print(f"Iteration {iteration}/{max_iterations}", file=sys.stderr)
+            print(f"Description: {current_description}", file=sys.stderr)
+            print(f"{'='*60}", file=sys.stderr)
+
+        # Evaluate train + test together in one batch for parallelism
+        all_queries = train_set + test_set
+        t0 = time.time()
+        all_results = run_eval(
+            eval_set=all_queries,
+            skill_name=name,
+            description=current_description,
+            num_workers=num_workers,
+            timeout=timeout,
+            project_root=project_root,
+            runs_per_query=runs_per_query,
+            trigger_threshold=trigger_threshold,
+            model=model,
+        )
+        eval_elapsed = time.time() - t0
+
+        # Split results back into train/test by matching queries
+        train_queries_set = {q["query"] for q in train_set}
+        train_result_list = [r for r in all_results["results"] if r["query"] in train_queries_set]
+        test_result_list = [r for r in all_results["results"] if r["query"] not in train_queries_set]
+
+        train_passed = sum(1 for r in train_result_list if r["pass"])
+        train_total = len(train_result_list)
+        train_summary = {"passed": train_passed, "failed": train_total - train_passed, "total": train_total}
+        train_results = {"results": train_result_list, "summary": train_summary}
+
+        if test_set:
+            test_passed = sum(1 for r in test_result_list if r["pass"])
+            test_total = len(test_result_list)
+            test_summary = {"passed": test_passed, "failed": test_total - test_passed, "total": test_total}
+            test_results = {"results": test_result_list, "summary": test_summary}
+        else:
+            test_results = None
+            test_summary = None
+
+        history.append({
+            "iteration": iteration,
+            "description": current_description,
+            "train_passed": train_summary["passed"],
+            "train_failed": train_summary["failed"],
+            "train_total": train_summary["total"],
+            "train_results": train_results["results"],
+            "test_passed": test_summary["passed"] if test_summary else None,
+            "test_failed": test_summary["failed"] if test_summary else None,
+            "test_total": test_summary["total"] if test_summary else None,
+            "test_results": test_results["results"] if test_results else None,
+            # For backward compat with report generator
+            "passed": train_summary["passed"],
+            "failed": train_summary["failed"],
+            "total": train_summary["total"],
+            "results": train_results["results"],
+        })
+
+        # Write live report if path provided
+        if live_report_path:
+            partial_output = {
+                "original_description": original_description,
+                "best_description": current_description,
+                "best_score": "in progress",
+                "iterations_run": len(history),
+                "holdout": holdout,
+                "train_size": len(train_set),
+                "test_size": len(test_set),
+                "history": history,
+            }
+            live_report_path.write_text(generate_html(partial_output, auto_refresh=True, skill_name=name))
+
+        if verbose:
+            def print_eval_stats(label, results, elapsed):
+                pos = [r for r in results if r["should_trigger"]]
+                neg = [r for r in results if not r["should_trigger"]]
+                tp = sum(r["triggers"] for r in pos)
+                pos_runs = sum(r["runs"] for r in pos)
+                fn = pos_runs - tp
+                fp = sum(r["triggers"] for r in neg)
+                neg_runs = sum(r["runs"] for r in neg)
+                tn = neg_runs - fp
+                total = tp + tn + fp + fn
+                precision = tp / (tp + fp) if (tp + fp) > 0 else 1.0
+                recall = tp / (tp + fn) if (tp + fn) > 0 else 1.0
+                accuracy = (tp + tn) / total if total > 0 else 0.0
+                print(f"{label}: {tp+tn}/{total} correct, precision={precision:.0%} recall={recall:.0%} accuracy={accuracy:.0%} ({elapsed:.1f}s)", file=sys.stderr)
+                for r in results:
+                    status = "PASS" if r["pass"] else "FAIL"
+                    rate_str = f"{r['triggers']}/{r['runs']}"
+                    print(f"  [{status}] rate={rate_str} expected={r['should_trigger']}: {r['query'][:60]}", file=sys.stderr)
+
+            print_eval_stats("Train", train_results["results"], eval_elapsed)
+            if test_summary:
+                print_eval_stats("Test ", test_results["results"], 0)
+
+        if train_summary["failed"] == 0:
+            exit_reason = f"all_passed (iteration {iteration})"
+            if verbose:
+                print(f"\nAll train queries passed on iteration {iteration}!", file=sys.stderr)
+            break
+
+        if iteration == max_iterations:
+            exit_reason = f"max_iterations ({max_iterations})"
+            if verbose:
+                print(f"\nMax iterations reached ({max_iterations}).", file=sys.stderr)
+            break
+
+        # Improve the description based on train results
+        if verbose:
+            print(f"\nImproving description...", file=sys.stderr)
+
+        t0 = time.time()
+        # Strip test scores from history so improvement model can't see them
+        blinded_history = [
+            {k: v for k, v in h.items() if not k.startswith("test_")}
+            for h in history
+        ]
+        new_description = improve_description(
+            skill_name=name,
+            skill_content=content,
+            current_description=current_description,
+            eval_results=train_results,
+            history=blinded_history,
+            model=model,
+            log_dir=log_dir,
+            iteration=iteration,
+        )
+        improve_elapsed = time.time() - t0
+
+        if verbose:
+            print(f"Proposed ({improve_elapsed:.1f}s): {new_description}", file=sys.stderr)
+
+        current_description = new_description
+
+    # Find the best iteration by TEST score (or train if no test set)
+    if test_set:
+        best = max(history, key=lambda h: h["test_passed"] or 0)
+        best_score = f"{best['test_passed']}/{best['test_total']}"
+    else:
+        best = max(history, key=lambda h: h["train_passed"])
+        best_score = f"{best['train_passed']}/{best['train_total']}"
+
+    if verbose:
+        print(f"\nExit reason: {exit_reason}", file=sys.stderr)
+        print(f"Best score: {best_score} (iteration {best['iteration']})", file=sys.stderr)
+
+    return {
+        "exit_reason": exit_reason,
+        "original_description": original_description,
+        "best_description": best["description"],
+        "best_score": best_score,
+        "best_train_score": f"{best['train_passed']}/{best['train_total']}",
+        "best_test_score": f"{best['test_passed']}/{best['test_total']}" if test_set else None,
+        "final_description": current_description,
+        "iterations_run": len(history),
+        "holdout": holdout,
+        "train_size": len(train_set),
+        "test_size": len(test_set),
+        "history": history,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run eval + improve loop")
+    parser.add_argument("--eval-set", required=True, help="Path to eval set JSON file")
+    parser.add_argument("--skill-path", required=True, help="Path to skill directory")
+    parser.add_argument("--description", default=None, help="Override starting description")
+    parser.add_argument("--num-workers", type=int, default=10, help="Number of parallel workers")
+    parser.add_argument("--timeout", type=int, default=30, help="Timeout per query in seconds")
+    parser.add_argument("--max-iterations", type=int, default=5, help="Max improvement iterations")
+    parser.add_argument("--runs-per-query", type=int, default=3, help="Number of runs per query")
+    parser.add_argument("--trigger-threshold", type=float, default=0.5, help="Trigger rate threshold")
+    parser.add_argument("--holdout", type=float, default=0.4, help="Fraction of eval set to hold out for testing (0 to disable)")
+    parser.add_argument("--model", required=True, help="Model for improvement")
+    parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
+    parser.add_argument("--report", default="auto", help="Generate HTML report at this path (default: 'auto' for temp file, 'none' to disable)")
+    parser.add_argument("--results-dir", default=None, help="Save all outputs (results.json, report.html, log.txt) to a timestamped subdirectory here")
+    args = parser.parse_args()
+
+    eval_set = json.loads(Path(args.eval_set).read_text())
+    skill_path = Path(args.skill_path)
+
+    if not (skill_path / "SKILL.md").exists():
+        print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
+        sys.exit(1)
+
+    name, _, _ = parse_skill_md(skill_path)
+
+    # Set up live report path
+    if args.report != "none":
+        if args.report == "auto":
+            timestamp = time.strftime("%Y%m%d_%H%M%S")
+            live_report_path = Path(tempfile.gettempdir()) / f"skill_description_report_{skill_path.name}_{timestamp}.html"
+        else:
+            live_report_path = Path(args.report)
+        # Open the report immediately so the user can watch
+        live_report_path.write_text("<html><body><h1>Starting optimization loop...</h1><meta http-equiv='refresh' content='5'></body></html>")
+        webbrowser.open(str(live_report_path))
+    else:
+        live_report_path = None
+
+    # Determine output directory (create before run_loop so logs can be written)
+    if args.results_dir:
+        timestamp = time.strftime("%Y-%m-%d_%H%M%S")
+        results_dir = Path(args.results_dir) / timestamp
+        results_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        results_dir = None
+
+    log_dir = results_dir / "logs" if results_dir else None
+
+    output = run_loop(
+        eval_set=eval_set,
+        skill_path=skill_path,
+        description_override=args.description,
+        num_workers=args.num_workers,
+        timeout=args.timeout,
+        max_iterations=args.max_iterations,
+        runs_per_query=args.runs_per_query,
+        trigger_threshold=args.trigger_threshold,
+        holdout=args.holdout,
+        model=args.model,
+        verbose=args.verbose,
+        live_report_path=live_report_path,
+        log_dir=log_dir,
+    )
+
+    # Save JSON output
+    json_output = json.dumps(output, indent=2)
+    print(json_output)
+    if results_dir:
+        (results_dir / "results.json").write_text(json_output)
+
+    # Write final HTML report (without auto-refresh)
+    if live_report_path:
+        live_report_path.write_text(generate_html(output, auto_refresh=False, skill_name=name))
+        print(f"\nReport: {live_report_path}", file=sys.stderr)
+
+    if results_dir and live_report_path:
+        (results_dir / "report.html").write_text(generate_html(output, auto_refresh=False, skill_name=name))
+
+    if results_dir:
+        print(f"Results saved to: {results_dir}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/skill-creator/scripts/utils.py
+++ b/.agents/skills/skill-creator/scripts/utils.py
@@ -1,0 +1,47 @@
+"""Shared utilities for skill-creator scripts."""
+
+from pathlib import Path
+
+
+
+def parse_skill_md(skill_path: Path) -> tuple[str, str, str]:
+    """Parse a SKILL.md file, returning (name, description, full_content)."""
+    content = (skill_path / "SKILL.md").read_text()
+    lines = content.split("\n")
+
+    if lines[0].strip() != "---":
+        raise ValueError("SKILL.md missing frontmatter (no opening ---)")
+
+    end_idx = None
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            end_idx = i
+            break
+
+    if end_idx is None:
+        raise ValueError("SKILL.md missing frontmatter (no closing ---)")
+
+    name = ""
+    description = ""
+    frontmatter_lines = lines[1:end_idx]
+    i = 0
+    while i < len(frontmatter_lines):
+        line = frontmatter_lines[i]
+        if line.startswith("name:"):
+            name = line[len("name:"):].strip().strip('"').strip("'")
+        elif line.startswith("description:"):
+            value = line[len("description:"):].strip()
+            # Handle YAML multiline indicators (>, |, >-, |-)
+            if value in (">", "|", ">-", "|-"):
+                continuation_lines: list[str] = []
+                i += 1
+                while i < len(frontmatter_lines) and (frontmatter_lines[i].startswith("  ") or frontmatter_lines[i].startswith("\t")):
+                    continuation_lines.append(frontmatter_lines[i].strip())
+                    i += 1
+                description = " ".join(continuation_lines)
+                continue
+            else:
+                description = value.strip('"').strip("'")
+        i += 1
+
+    return name, description, content

--- a/.claude/skills/skill-creator
+++ b/.claude/skills/skill-creator
@@ -1,0 +1,1 @@
+../../.agents/skills/skill-creator

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 node_modules
 *.log
 agent-skills-workspace
+examples/quick-review/evals/fixture-repo

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Open `iteration-1/report/index.html` and you have a real, evidence-backed answer
 | **Judge-graded outputs** | Use any chat model as a judge. Pass/fail with cited assertions, not vibes. |
 | **TypeScript SDK + CLI** | One-liner CLI for CI, full SDK for custom pipelines, custom providers, and dashboards. |
 | **OpenAI-compatible by default** | Works out of the box with OpenAI, Together, Groq, Anthropic via OpenAI-compat layers, local Llama servers — anything that speaks the OpenAI chat API. |
+| **Pluggable execution: API or agentic CLI** | Run target/judge through any OpenAI-compatible API, or drive the real [`opencode`](https://opencode.ai) CLI (its own tool use, permissions, agent config) via `--run-mode opencode`. |
 | **Tool-call assertions** | Deterministic checks for agents that call tools, not just generate text. |
 | **Portable artifacts** | JSON + JSONL all the way down. Run today, diff tomorrow. Plug into your own dashboard. |
 | **Static HTML reports** | A drop-in report site you can publish anywhere — no infrastructure. |
@@ -116,6 +117,8 @@ The mental model is straightforward. For every eval defined in your skill:
 ```
 
 The judge sees the eval's `expected_output` and `assertions` and grades each side independently. The `--baseline` flag is what enables the comparison; without it you only get the `with_skill` run.
+
+This is the *logical* flow regardless of run mode — `--run-mode opencode` (below) changes *how* the target/judge models are invoked (a subprocess instead of an HTTP call), not this flow.
 
 ## YAML config
 
@@ -234,6 +237,53 @@ export const provider: Provider = {
 
 Useful for: local model servers (Ollama, vLLM, llama.cpp), proprietary internal APIs, mock providers in unit tests, or routing layers in front of multiple providers.
 
+## opencode run mode
+
+Instead of calling an OpenAI-compatible API directly, you can route target/judge calls through [`opencode`](https://opencode.ai) via `@opencode-ai/sdk` — useful if you already manage model access/credentials through opencode and don't want to supply a separate `--base-url`/API key to this tool.
+
+```bash
+npx agent-skills-eval ./skills \
+  --run-mode opencode \
+  --target anthropic/claude-sonnet-5 \
+  --opencode-agent build \
+  --opencode-timeout 300000
+```
+
+| Flag | Description |
+|---|---|
+| `--run-mode <api\|opencode>` | Default `api`. Set to `opencode` to talk to an opencode server instead of calling an HTTP API. |
+| `--target` / `--judge` | In opencode mode, must be `provider/model` form (e.g. `anthropic/claude-sonnet-5`), matching opencode's own model id syntax. |
+| `--opencode-agent <name>` | Which opencode agent handles the session (e.g. `build`). |
+| `--opencode-dir <path>` | Working directory opencode runs in. Default: current directory. |
+| `--opencode-auto` / `--no-opencode-auto` | Auto-approve opencode's own permission prompts (edit/bash/webfetch/etc). **Dangerous, off by default** — see caveat below. `--no-opencode-auto` always overrides `opencode.auto: true` set in a config file. |
+| `--opencode-timeout <ms>` | Hard deadline per call — covers the initial prompt, waiting on any delegated subagent work, and follow-up continuations. Default `300000` (5 minutes). |
+| `--opencode-judge-timeout <ms>` | Hard deadline for judge/grader calls specifically. Defaults to `--opencode-timeout`. A judge that reads a full transcript plus output files is often slower than the run it grades — set this higher if judge calls are timing out. |
+
+Equivalent YAML:
+
+```yaml
+runMode: opencode
+opencode:
+  agent: build
+  auto: false
+  dir: ./workspace-scratch
+  timeoutMs: 300000
+  judgeTimeoutMs: 600000
+  # baseUrl: http://127.0.0.1:4096  # talk to an already-running `opencode serve` instead of spawning one
+```
+
+**Skills are loaded natively, not injected into the prompt.** In every other run mode, `with_skill` works by wrapping the skill in an XML block and prepending it to the prompt. In opencode mode, that would never happen in real-world use — opencode discovers skills on disk and loads them itself via its own `skill` tool (see [opencode's Agent Skills docs](https://opencode.ai/docs/skills/)). So instead, before each call this provider symlinks every entry of the skill's directory into `<opencode.dir>/.opencode/skills/<name>/` for `with_skill` runs, and removes that symlink tree for `without_skill` runs — the agent decides for itself whether to call `skill({ name })`. The skill's `evals/` folder (which holds the answer key) is never linked. No `system` message is sent in this mode; the model gets the bare eval prompt either way.
+
+**How a call works.** Each `complete()` call spawns a fresh, private `opencode serve` process (via `createOpencodeServer`, on an auto-assigned port so concurrent target/judge calls don't collide), creates one session, and sends the prompt. opencode's own subagent delegation (the `delegate`/`task` tool — see [opencode's Agents docs](https://opencode.ai/docs/agents/)) is asynchronous: the model's turn ends the moment it dispatches a delegation, and the delegate's result is delivered later as a message appended to the same session, once it finishes. A single request/response can't wait for that, so this provider keeps its private server alive after the initial prompt resolves and polls the session (and any child sessions opencode created for delegated work) until they go idle. It then sends a bounded number of follow-up "Continue." prompts (`maxContinuations`, capped internally) if either: the session's last message is still an unanswered delegation notification rather than the model's own reply, or the model's own reply is a premature "waiting on delegation" stub — dispatched a delegation but never read its result back with `delegation_read` — that would otherwise look structurally identical to a real final answer. All of this is bounded by `--opencode-timeout` as the overall deadline. The server is always torn down afterward, even on error or timeout. Its combined stdout/stderr is captured for the whole run and written to `outputs/opencode-serve.log` alongside the other run artifacts, so a crashed or misbehaving server is diagnosable after the fact.
+
+**Caveats:**
+
+- **Token/cost numbers aren't comparable to API mode.** opencode's own system prompt and tool schemas add fixed overhead to every call (observed ~8,400 input tokens for a trivial one-word prompt), so `inputTokens`/`outputTokens`/`costUsd` from opencode-mode runs are not apples-to-apples with the same model called via `OpenAICompatibleProvider`.
+- **`--opencode-auto` is dangerous.** It lets the target/judge model run opencode's own bash/file-edit tools completely unattended for the duration of the call. It's off by default. Even without it, a stuck interactive permission prompt has no TTY to answer in a non-interactive eval run — that's what `--opencode-timeout` guards against; it always applies, whether or not `--opencode-auto` is set.
+- **No custom binary path.** Unlike older versions of this provider, there's no way to point at a non-`PATH` opencode binary — `@opencode-ai/sdk` always spawns `opencode` resolved via `PATH`. Point `PATH` at the right install, or use `opencode.baseUrl` to talk to a server you started yourself.
+- **`tool_assertions` see opencode's own internal tools, not a caller-supplied schema.** This provider reports every tool call opencode's agent actually made during the run (`bash`, file edits, `task` delegation, `skill`, etc.) as `ProviderResult.toolCalls`, written to `tool_calls.json` and shown in the HTML report — including, for `with_skill` runs, whether the `skill` tool was called with this eval's skill name (surfaced as a "skill picked up" badge). `tool_assertions` grade against that same list, so e.g. `{"type": "tool-called", "name": "skill"}` works under `--run-mode opencode`, but there's no `tools`/`tool_choice` schema to pass *in* — the model always has whatever tools opencode itself exposes, never a caller-defined set.
+- **Shared working directory.** All calls from one CLI invocation share a single `--opencode-dir`. If a skill has the model write files, or you run `with_skill`/`without_skill` for the same skill concurrently, use `--concurrency 1` — otherwise the on-disk skill symlink one call installs/removes can race another call's `.opencode/skills/<name>/` lookup, or concurrent git operations against the same working tree.
+
 ## Skill layout
 
 A skill is a folder. The minimum is a `SKILL.md`. Add `evals/evals.json` and you can evaluate it.
@@ -308,6 +358,16 @@ npx agent-skills-eval [root] \
 ```
 
 **Logging modes**: `pretty` for humans, `jsonl` for machines, `silent` for quiet CI.
+
+Or run via the [opencode CLI](#opencode-run-mode) instead of an API:
+
+```bash
+npx agent-skills-eval [root] \
+  --run-mode opencode \
+  --target anthropic/claude-sonnet-5 \
+  --opencode-agent build \
+  --opencode-timeout 300000
+```
 
 ## Reports
 

--- a/examples/agent-skills-eval.quick-review.yaml
+++ b/examples/agent-skills-eval.quick-review.yaml
@@ -1,0 +1,35 @@
+# Run from the repo root:
+#   uv run examples/quick-review/evals/setup_fixture.py   # (re)build the fixture repo
+#   npx agent-skills-eval --config examples/agent-skills-eval.quick-review.yaml
+#
+# quick-review is a fully agentic skill (it runs git/uv commands via
+# scripts/review-tools.py), so — unlike basic-skill — it needs --run-mode
+# opencode to get real Bash/file access instead of a single chat completion.
+#
+# concurrency MUST stay at 1: every eval and every with_skill/without_skill
+# run shares the one `opencode.dir` fixture repo. Running more than one at a
+# time means concurrent git operations against the same working tree.
+#
+# opencode.auto is required for a headless run (there's no human to approve
+# opencode's bash/file-edit tool prompts) but it's a real, unattended
+# auto-approval of tool use in that directory — see the opencode-provider
+# README section before flipping it on elsewhere.
+root: ./examples/quick-review
+workspace: ./agent-skills-workspace
+baseline: true
+target: tensorix/minimax/minimax-m3
+runMode: opencode
+opencode:
+  dir: ./examples/quick-review/evals/fixture-repo
+  auto: true
+  timeoutMs: 1200000
+concurrency: 1
+layout: iteration
+strict: true
+report:
+  enabled: true
+  title: Quick Review Example Report
+logging:
+  format: pretty
+  verbose: false
+  color: auto

--- a/examples/quick-review/SKILL.md
+++ b/examples/quick-review/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: quick-review
+description: 'Single-pass bird''s-eye code review across 5 dimensions: Correctness, Design, Maintainability, Security, Risk & Operations. Use when asked to "quick review", "fast review", "review my MR", "review PR", "review staged", "review my branch", "check my code". Lower token usage than super-review: no sub-agents, no forensic line-by-line pass — bird''s view only. Auto-discovers conventions. Posts results via glab or gh, or renders a Markdown report locally. Skips mechanical concerns (linting, formatting, compilation) — CI owns those.'
+---
+
+# Quick Review
+
+Single-pass 5-dimension code review, bird's-view only. All evaluation happens in one inline pass.
+
+There are 4 steps, use a todo list to mark progress:
+
+1. context
+2. changeset
+3. bird's-eye evaluation
+4. output
+
+---
+
+## Step 1 — Context
+
+### Platform Detection
+
+| User mentions | Mode | Requirement |
+|---|---|---|
+| MR / merge request | `glab` | glab skill required — **abort if unavailable** |
+| PR / pull request | `gh` | gh CLI required — **abort if unavailable** |
+| staged / working / branch / nothing specific | `local` | none |
+
+**glab:** identify the MR → glab skill *Identifying the Current MR*.  
+**gh:** `gh pr view --json number,title,body`.
+
+---
+
+### Issue Context (best-effort)
+
+Run `uv run scripts/review-tools.py extract-issue-ref` to extract an issue number from the branch name.  
+Also scan MR/PR title and description for refs (`Closes #123`, `Relates to #456`).
+
+Fetch issue details if found:
+- glab → glab skill *Fetching Related Issues*
+- gh → `gh issue view <N>`
+
+On failure: set `context = {}`, note "Issue context unavailable".
+
+Result: `context = {problem, constraints, expected_outcomes}`
+
+---
+
+### Convention Discovery (best-effort)
+
+Run `uv run scripts/review-tools.py find-conventions` to locate and print relevant guideline files. Summarise as `coding_guidelines`.
+
+---
+
+## Step 2 — Changeset
+
+| Mode | Action |
+|---|---|
+| `glab` | glab skill: *Fetching MR Data* (diffs endpoint) |
+| `gh` | `gh pr diff <number>` |
+| `local` — staged | `uv run scripts/review-tools.py get-staged` |
+| `local` — working tree | `uv run scripts/review-tools.py get-working` |
+| `local` — branch / default | `uv run scripts/review-tools.py get-branch` |
+
+**Abort** if the diff is empty.
+
+Produce a **mental model** (≤150 words): what changed, why, key data flows affected. This is the only input to Step 3.
+
+---
+
+## Step 3 — Bird's-Eye Evaluation
+
+Evaluate all 5 dimensions in a **single inline pass** using the mental model, `context`, and `coding_guidelines` from the previous steps.
+
+For each dimension, answer the probe questions below and emit any issues found.
+
+---
+
+### Correctness
+
+**Core question:** Is the overall approach algorithmically correct?
+
+- Is the algorithm or flow fundamentally correct for the stated requirement?
+- Are entire categories of input or state systematically unhandled (empty collections, unauthenticated paths, concurrent modifications)?
+- Does the change implement the right thing — or the right thing incorrectly?
+- Are domain invariants preserved across the whole change?
+
+---
+
+### Design
+
+**Core question:** Is this a good way to solve the problem in this system?
+
+- Does the overall approach fit the existing architecture, or does it introduce a conflicting pattern?
+- Is responsibility correctly assigned — or is this logic in the wrong layer / component?
+- Does the change increase coupling between components that should be independent?
+- Are new abstractions the right level, or are they leaking or premature?
+- Does the design leave room to evolve, or does it bake in assumptions?
+
+---
+
+### Maintainability
+
+**Core question:** Will the next maintainer understand this?
+
+- Does the overall change increase or decrease cognitive load?
+- Is it consistent with existing patterns, or does it introduce a new idiom without justification?
+- Is complexity growing in a compounding way (deeply nested conditionals, growing god classes)?
+- Is the intent self-evident from the structure, or does it require tribal knowledge?
+- Do new or modified public APIs (functions, classes, modules) have accurate docstrings?
+- Is non-obvious logic accompanied by a WHY-comment (motivation, not just mechanics)?
+- Does the change affect user-visible behavior, configuration, or public APIs in a way that requires README or external doc updates?
+- If user-visible behavior changed, is a changelog entry present?
+
+---
+
+### Security
+
+**Core question:** Are trust boundaries preserved?
+
+- Are trust boundaries maintained across the change? Does it shift who is trusted?
+- Is the authorization model consistent, or does this path skip a check every other path enforces?
+- Does the change expose a new attack surface (endpoint, input path, integration)?
+- Are secrets, credentials, or PII handled with the same care as the rest of the system?
+- Does the change violate least privilege at the architectural level?
+
+---
+
+### Risk & Operations
+
+**Core question:** What happens when this fails in production?
+
+- What is the blast radius if this fails? Scoped or cascading?
+- Does the change introduce a new failure mode the on-call team is unprepared for?
+- Is observability coherent — are the right signals present for the new behavior?
+- Is the deployment safe? Does it require a coordinated release, migration, or feature flag?
+- Can this be rolled back without data loss or breaking dependents?
+
+---
+
+### Issue Format
+
+Emit each finding as:
+
+```
+severity: must-fix | should-fix | consider | optional
+category: <dimension name>
+title: <one line, concrete>
+description: <what is wrong and why it matters>
+file: <path or null>
+line: <number or null>
+suggestion: <concrete fix or null>
+```
+
+Do not flag: linting, formatting, compilation, test coverage — CI owns those.
+
+Deduplicate: remove exact duplicates; keep the most specific when two dimensions flag the same concern, note "(also flagged by {Dimension})".
+
+---
+
+## Step 4 — Output
+
+### glab mode
+
+Use glab skill patterns *Posting Review Threads* and *Updating an MR*.
+
+- `must-fix` + `should-fix` → one inline thread each
+- `consider` + `optional` → batched into the final summary note
+- Fall back to MR-level note if inline positioning fails
+- Post one summary note via `glab mr note`
+- **Confirm with the user before posting**
+
+Inline thread format:
+
+```
+**[{Category}] {Severity label}** {title}
+
+{description}
+
+**Suggestion:**
+```lang
+{suggestion}
+```
+```
+
+---
+
+### gh mode
+
+- Any `must-fix` → `gh pr review --request-changes`
+- `should-fix` / `consider` only → `gh pr review --comment`
+- Inline where file+line are available; general comment otherwise
+- **Confirm with the user before posting**
+
+---
+
+### local mode
+
+Render the report below in the chat response.
+
+---
+
+### Severity Labels
+
+| Value | Label | Action |
+|---|---|---|
+| `must-fix` | 🔴 Must Fix | Blocks merge |
+| `should-fix` | 🟠 Should Fix | Address before merge |
+| `consider` | 🟡 Consider | Worth discussing |
+| `optional` | 🔵 Optional | Minor preference |
+
+---
+
+### Report Template
+
+See: `references/report_template.md`
+
+
+
+---
+
+### Rules
+
+- Never post without explicit user confirmation
+- Skip findings already in existing review threads
+- Always include "What's Working Well"
+- Omit empty severity sections

--- a/examples/quick-review/evals/README.md
+++ b/examples/quick-review/evals/README.md
@@ -1,0 +1,72 @@
+# quick-review evals
+
+`quick-review` is a fully agentic skill — it runs `git`/`uv` commands via
+`scripts/review-tools.py` and, in glab/gh mode, shells out to `glab`/`gh` — not
+a single text-in/text-out transform like `basic-skill`. That changes how it
+has to be tested in this framework.
+
+## Why these evals need `--run-mode opencode`
+
+The default `api` run mode sends the skill as a system prompt and gets back
+one chat completion — there's no real Bash/file execution, so
+`uv run scripts/review-tools.py get-staged` etc. can't actually run. Testing
+this skill for real means using `--run-mode opencode`, which shells out to a
+real `opencode` agent with real tool access, running in a real git repo.
+
+## The fixture
+
+Because `--run-mode opencode` shares one `opencode.dir` across every eval and
+every `with_skill`/`without_skill` run in a single CLI invocation, the three
+evals here can't each get their own repo. Instead, `setup_fixture.py` builds
+**one** repo with three independent diffs baked in simultaneously:
+
+| Diff | git state | Eval | Planted issues |
+|---|---|---|---|
+| branch vs `origin/main` | `feature/456-add-transfer`, 1 commit ahead | `review-branch-transfer-endpoint` | SQL injection (f-string), missing authorization check, no amount validation, no transaction/rollback |
+| staged (index) | `git add`-ed on top of the branch commit | `review-staged-remember-me` | plaintext password in a "remember me" cookie, unauthenticated destructive `reset_all_balances()` |
+| working tree (unstaged) | on top of the staged changes | `review-working-tree-audit-logging` | logs the raw password, deeply nested duplicate conditionals, missing docstring |
+
+A `CONTRIBUTING.md` is committed alongside with conventions that each planted
+issue actually violates (authorization checks required, never log secrets,
+wrap multi-step balance updates in a transaction), so the skill's
+convention-discovery step has something real to find and the reviews can be
+graded on whether they connect findings back to it.
+
+Rebuild the fixture any time with:
+
+```bash
+uv run examples/quick-review/evals/setup_fixture.py
+```
+
+It deletes and recreates `evals/fixture-repo/` from scratch, so it's safe to
+re-run after a run that left the repo dirty (e.g. a `without_skill` baseline
+that "fixed" something instead of just reviewing it — see the caveat below).
+
+## Running
+
+```bash
+uv run examples/quick-review/evals/setup_fixture.py
+npx agent-skills-eval --config examples/agent-skills-eval.quick-review.yaml
+```
+
+The config pins `runMode: opencode`, `opencode.dir` at the fixture repo, and
+`concurrency: 1`. **Don't raise concurrency for this skill** — every run
+shares the same working directory, so running more than one at a time means
+concurrent git operations (checkouts, staging, commits) against the same
+working tree, which will corrupt the fixture state mid-run.
+
+`opencode.auto: true` is also load-bearing here: without it, the opencode
+subprocess has no human to approve its Bash/file-edit tool calls and will
+hang. It's scoped to the throwaway fixture directory, but it is a real,
+unattended auto-approval of tool use — see the "opencode run mode" section of
+the main README before reusing this pattern against a real repo.
+
+## A note on the `without_skill` baseline
+
+`--baseline` (set via `baseline: true`) runs both `with_skill` and
+`without_skill` against the same prompts and the same fixture repo. The
+prompts ask for a *review*, not a fix, so a reasonable agent should only read
+the repo — but nothing stops a baseline run without the skill's instructions
+from deciding to "helpfully" edit the code instead of just describing what's
+wrong. If a run looks suspicious (e.g. `git diff` output doesn't match what
+`setup_fixture.py` printed), re-run the setup script before evaluating again.

--- a/examples/quick-review/evals/evals.json
+++ b/examples/quick-review/evals/evals.json
@@ -1,0 +1,49 @@
+{
+  "skill_name": "quick-review",
+  "evals": [
+    {
+      "id": "review-branch-transfer-endpoint",
+      "name": "review branch — transfer endpoint",
+      "prompt": "I've been working on branch feature/456-add-transfer and think it's ready. Can you do a quick review of my branch before I open a PR?",
+      "expected_output": "A local-mode quick-review report (branch vs main) of just the new transfer() function, flagging the SQL injection from f-string-interpolated queries, the missing check that current_user_id actually owns from_id, the lack of amount validation, and the lack of transaction/rollback safety across the two balance updates — plus a 'What's Working Well' section and no lint/formatting nitpicks.",
+      "assertions": [
+        "The review flags that transfer() builds SQL queries by interpolating variables directly into the string (f-string), which is a SQL injection risk.",
+        "The review flags that transfer() never checks current_user_id against from_id, so any authenticated user could drain any account.",
+        "The review flags that transfer() does not validate amount (e.g. rejecting negative or zero amounts).",
+        "The review flags that the two balance UPDATE statements aren't wrapped in a transaction/rollback, so a failure between them could leave balances inconsistent.",
+        "The output includes a 'What's Working Well' section with at least one concrete positive observation.",
+        "The output uses the skill's severity taxonomy (must-fix/should-fix/consider/optional, or their emoji labels) rather than an unstructured list.",
+        "None of the review's findings are linting, formatting, or compilation nitpicks (e.g. import ordering, PEP 8 style, missing type hints) — a review that simply never raises any such finding satisfies this; it does not need to explicitly state that it considered and excluded them.",
+        "None of the review's severity-tagged findings (must-fix/should-fix/consider/optional, or emoji equivalents) treats reset_all_balances(), the remember-me cookie, or audit_login() as an issue to fix in this review, since none of them are part of this branch-vs-main diff. A brief comparative aside (e.g. contrasting transfer()'s raw SQL with another function's parameterized queries) is fine; raising one of those functions as a finding is not."
+      ]
+    },
+    {
+      "id": "review-staged-remember-me",
+      "name": "review staged — remember-me + reset endpoint",
+      "prompt": "I've staged a 'remember me' option for login plus a quick balance-reset helper for the ops dashboard. Can you quick review what's staged before I commit?",
+      "expected_output": "A local-mode quick-review report of the staged changes only, flagging the plaintext password stored in the remember-me cookie and the fact that reset_all_balances has no authentication or authorization check given how destructive it is, ideally tying these back to the project's own CONTRIBUTING.md conventions.",
+      "assertions": [
+        "The review flags that the remember-me cookie stores the raw/plaintext password (f\"{username}:{password}\"), not a token or hash.",
+        "The review flags that reset_all_balances() has no authentication or authorization check despite resetting every account's balance.",
+        "The review references or aligns with the project's own coding guideline (from CONTRIBUTING.md) about requiring authorization checks and/or not exposing secrets/credentials.",
+        "The output includes a 'What's Working Well' section with at least one concrete positive observation.",
+        "None of the review's findings are linting, formatting, or compilation nitpicks (e.g. import ordering, PEP 8 style, missing type hints) — a review that simply never raises any such finding satisfies this; it does not need to explicitly state that it considered and excluded them."
+      ]
+    },
+    {
+      "id": "review-working-tree-audit-logging",
+      "name": "review working tree — audit logging",
+      "prompt": "Quick review my working tree changes — I added some audit logging around login attempts before I stage them.",
+      "expected_output": "A local-mode quick-review report of all uncommitted changes (staged + unstaged), flagging that audit_login logs the raw password in plaintext and that its deeply nested if/else structure duplicates the same logging call four times, in addition to the still-uncommitted remember-me cookie and reset_all_balances issues.",
+      "assertions": [
+        "The review flags that audit_login logs the raw password value in plaintext via logger.info/logger.warning.",
+        "The review flags the deeply nested, duplicated if/else structure in audit_login as a maintainability/cognitive-load concern (or suggests simplifying it).",
+        "The review notes that audit_login has no docstring while the other new functions in the diff do.",
+        "The review also flags the remember-me plaintext cookie and/or the unauthenticated reset_all_balances(), since git diff HEAD includes staged as well as unstaged changes.",
+        "The review references or aligns with the project's own coding guideline (from CONTRIBUTING.md) about never logging secrets or passwords.",
+        "The output includes a 'What's Working Well' section with at least one concrete positive observation.",
+        "None of the review's findings are linting, formatting, or compilation nitpicks (e.g. import ordering, PEP 8 style, missing type hints) — a review that simply never raises any such finding satisfies this; it does not need to explicitly state that it considered and excluded them."
+      ]
+    }
+  ]
+}

--- a/examples/quick-review/evals/setup_fixture.py
+++ b/examples/quick-review/evals/setup_fixture.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""setup_fixture.py — builds a throwaway git repo for quick-review's opencode evals.
+
+`--run-mode opencode` gives the model real Bash/file access but every eval in
+one CLI invocation shares a single `--opencode-dir`, so we can't hand each
+eval its own repo. Instead this builds ONE repo with three independent diffs
+baked in at once, so a single shared working directory can satisfy all three
+`evals.json` cases:
+
+  1. a commit on `feature/456-add-transfer`, one commit ahead of a fake
+     `origin/main` -> exercises `get-branch`
+  2. staged (index) changes on top of that commit         -> exercises `get-staged`
+  3. unstaged working-tree changes on top of that          -> exercises `get-working`
+
+Each stage plants specific, findable issues (SQL injection, a missing
+authorization check, a plaintext-password cookie, an unauthenticated
+destructive endpoint, logged credentials, deeply nested duplicate
+conditionals) so the resulting review can be graded against concrete
+assertions. A CONTRIBUTING.md is committed alongside so the skill's
+convention-discovery step has something real to find and cite.
+
+Safe to re-run: the target directory is deleted and rebuilt from scratch
+every time, so a run that got mutated by an agent (e.g. a without_skill
+baseline that tried to "fix" things instead of just reviewing) can always be
+reset to a clean state before the next `agent-skills-eval` invocation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+from pathlib import Path
+
+HEADER = '''"""Tiny account service — fixture repo for the quick-review skill's evals."""
+import sqlite3
+
+DB_PATH = "accounts.db"
+'''
+
+GET_CONNECTION = '''
+
+def get_connection():
+    return sqlite3.connect(DB_PATH)
+'''
+
+HASH_PASSWORD = '''
+
+def hash_password(password: str) -> str:
+    import hashlib
+
+    return hashlib.sha256(password.encode()).hexdigest()
+'''
+
+GET_USER_BY_ID = '''
+
+def get_user_by_id(user_id: int):
+    conn = get_connection()
+    cursor = conn.execute(
+        "SELECT id, username, balance FROM users WHERE id = ?", (user_id,)
+    )
+    return cursor.fetchone()
+'''
+
+LOGIN_V1 = '''
+
+def login(username: str, password: str) -> bool:
+    conn = get_connection()
+    cursor = conn.execute(
+        "SELECT id FROM users WHERE username = ? AND password_hash = ?",
+        (username, hash_password(password)),
+    )
+    return cursor.fetchone() is not None
+'''
+
+# --- branch commit addition: SQL injection, no authz check, no rollback ---
+TRANSFER = '''
+
+def transfer(from_id: int, to_id: int, amount: float, current_user_id: int):
+    """Move `amount` from one account to another."""
+    conn = get_connection()
+    conn.execute(
+        f"UPDATE users SET balance = balance - {amount} WHERE id = {from_id}"
+    )
+    conn.execute(
+        f"UPDATE users SET balance = balance + {amount} WHERE id = {to_id}"
+    )
+    conn.commit()
+    return {"status": "ok"}
+'''
+
+# --- staged addition: plaintext password cookie + unauthenticated reset ---
+LOGIN_V2 = '''
+
+def login(username: str, password: str, remember_me: bool = False) -> dict:
+    conn = get_connection()
+    cursor = conn.execute(
+        "SELECT id FROM users WHERE username = ? AND password_hash = ?",
+        (username, hash_password(password)),
+    )
+    row = cursor.fetchone()
+    if row is None:
+        return {"ok": False}
+
+    result = {"ok": True, "user_id": row[0]}
+    if remember_me:
+        # Persist credentials so the user does not have to log in again.
+        result["remember_me_cookie"] = f"{username}:{password}"
+    return result
+'''
+
+RESET_ALL_BALANCES = '''
+
+def reset_all_balances(new_balance: float = 0.0):
+    """Reset every account to `new_balance`. Used by the ops dashboard."""
+    conn = get_connection()
+    conn.execute("UPDATE users SET balance = ?", (new_balance,))
+    conn.commit()
+'''
+
+# --- unstaged addition: logs the raw password, deeply nested duplicate branches ---
+AUDIT_LOGGING = '''
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def audit_login(username: str, password: str, success: bool):
+    if success:
+        if username:
+            if password:
+                logger.info("login success user=%s password=%s", username, password)
+            else:
+                logger.info("login success user=%s", username)
+        else:
+            logger.info("login success (no username)")
+    else:
+        if username:
+            logger.warning("login failed user=%s password=%s", username, password)
+        else:
+            logger.warning("login failed (no username)")
+'''
+
+CONTRIBUTING = """# Contributing
+
+## Coding Guidelines
+
+- Every endpoint or function that touches account balances or credentials
+  must include an explicit authorization check tying the request to the
+  authenticated user.
+- Never log secrets, passwords, or full account numbers — mask or omit them.
+- Wrap multi-step balance updates in a transaction; a partial failure must
+  never leave balances inconsistent.
+"""
+
+
+def run(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "target",
+        nargs="?",
+        default=str(Path(__file__).parent / "fixture-repo"),
+        help="Directory to (re)create the fixture repo in. Default: evals/fixture-repo",
+    )
+    args = parser.parse_args()
+    target = Path(args.target).resolve()
+
+    if target.exists():
+        shutil.rmtree(target)
+    target.mkdir(parents=True)
+
+    run(target, "init", "-q", "-b", "main")
+    run(target, "config", "user.email", "fixture@example.com")
+    run(target, "config", "user.name", "Fixture Bot")
+
+    main_content = HEADER + GET_CONNECTION + HASH_PASSWORD + GET_USER_BY_ID + LOGIN_V1
+    (target / "app.py").write_text(main_content)
+    (target / "CONTRIBUTING.md").write_text(CONTRIBUTING)
+    run(target, "add", "-A")
+    run(target, "commit", "-q", "-m", "Initial account service")
+
+    # Fake origin/main so review-tools.py's get-branch auto-detection works
+    # without a real network remote.
+    run(target, "update-ref", "refs/remotes/origin/main", "HEAD")
+    run(target, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+
+    run(target, "checkout", "-q", "-b", "feature/456-add-transfer")
+    branch_content = main_content + TRANSFER
+    (target / "app.py").write_text(branch_content)
+    run(target, "add", "-A")
+    run(target, "commit", "-q", "-m", "Add balance transfer endpoint")
+
+    # Staged: swap login() for the remember-me version, add reset_all_balances().
+    staged_content = (
+        HEADER + GET_CONNECTION + HASH_PASSWORD + GET_USER_BY_ID + LOGIN_V2 + TRANSFER + RESET_ALL_BALANCES
+    )
+    (target / "app.py").write_text(staged_content)
+    run(target, "add", "-A")
+
+    # Unstaged: append audit logging on top, left out of the index.
+    working_content = staged_content + AUDIT_LOGGING
+    (target / "app.py").write_text(working_content)
+
+    print(f"Fixture repo ready at {target}")
+    print("  branch:  feature/456-add-transfer, 1 commit ahead of origin/main (transfer())")
+    print("  staged:  remember-me cookie + reset_all_balances()")
+    print("  working: + audit_login() logging the raw password")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/quick-review/references/report_template.md
+++ b/examples/quick-review/references/report_template.md
@@ -1,0 +1,62 @@
+# Code Review — {mr_title | branch_name | "Local Changes"}
+
+**Scope:** {staged | working tree | branch vs {base} | MR!{N} | PR#{N}}
+**Date:** {YYYY-MM-DD}
+
+---
+
+## Context
+
+| | |
+|---|---|
+| **Problem** | {context.problem or "—"} |
+| **Constraints** | {context.constraints or "—"} |
+| **Conventions** | {coding_guidelines summary or "None discovered"} |
+
+---
+
+## Summary
+
+| Dimension | 🔴 | 🟠 | 🟡 | 🔵 |
+|---|:---:|:---:|:---:|:---:|
+| Correctness | {N} | {N} | {N} | {N} |
+| Design | {N} | {N} | {N} | {N} |
+| Maintainability | {N} | {N} | {N} | {N} |
+| Security | {N} | {N} | {N} | {N} |
+| Risk & Operations | {N} | {N} | {N} | {N} |
+
+**Verdict:** {✅ Approved | ⚠️ Needs Work | 🚫 Blocked}
+
+---
+
+## 🔴 Must Fix
+
+{For each must-fix finding:}
+#### {title} `{file}:{line}`
+{description}
+
+```
+{suggestion}
+```
+
+---
+
+## 🟠 Should Fix
+
+{For each should-fix finding:}
+#### {title} `{file}:{line}`
+{description}
+
+> {suggestion}
+
+---
+
+## 🟡 Consider / 🔵 Optional
+
+{List as bullets: **[Category]** title — description}
+
+---
+
+## What's Working Well
+
+{2–4 concrete positive observations from the diff}

--- a/examples/quick-review/scripts/review-tools.py
+++ b/examples/quick-review/scripts/review-tools.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "typer>=0.12",
+#     "rich>=13",
+# ]
+# ///
+"""
+review-tools.py — git helpers for review skill.
+
+Subcommands:
+  extract-issue-ref   Extract issue number from the current branch name
+  find-conventions    Locate and print project convention/guideline files
+  get-branch          Diff between the current branch and the base branch
+  get-staged          Diff of staged (index) changes
+  get-working         Diff of working tree changes
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from rich import print as rprint
+
+app = typer.Typer(
+    name="review-tools",
+    help=(
+        "Git-aware helpers for code review workflows.\n\n"
+        "Run [bold]review-tools COMMAND --help[/] for details on each subcommand."
+    ),
+    no_args_is_help=True,
+    rich_markup_mode="rich",
+)
+
+
+def _git(*args: str) -> tuple[str, int]:
+    cmd = ["rtk", "git", *args] if shutil.which("rtk") else ["git", *args]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    return result.stdout.strip(), result.returncode
+
+
+@app.command()
+def extract_issue_ref() -> None:
+    """Extract the issue number from the current branch name.
+
+    Looks for a numeric ref after '/' or '#' (e.g. feat/123-thing → 123)
+    and prints it to stdout.
+    """
+    branch, rc = _git("rev-parse", "--abbrev-ref", "HEAD")
+    if rc != 0 or not branch:
+        rprint("[bold red]Error:[/] Not in a git repo.", file=sys.stderr)
+        raise typer.Exit(code=1)
+
+    match = re.search(r"[/#](\d+)", branch)
+    if not match:
+        rprint(
+            f"[bold red]Error:[/] No issue ref found in branch: {branch}",
+            file=sys.stderr,
+        )
+        raise typer.Exit(code=1)
+
+    print(match.group(1))
+
+
+@app.command()
+def find_conventions() -> None:
+    """Locate project convention/guideline files and report their sizes.
+
+    Searches for CONTRIBUTING.md, *guidelines*, *standards*, and *conventions*
+    files under the current directory, excluding .git and node_modules.
+    Prints each file path and its word count.
+    """
+    _EXCLUDE = {".git", "node_modules"}
+    _PATTERNS = ["CONTRIBUTING.md", "*guidelines*", "*standards*", "*conventions*"]
+
+    seen: set[Path] = set()
+    files: list[Path] = []
+    for pattern in _PATTERNS:
+        for f in sorted(Path(".").rglob(pattern)):
+            if any(part in _EXCLUDE for part in f.parts) or not f.is_file():
+                continue
+            if f not in seen:
+                seen.add(f)
+                files.append(f)
+    files.sort()
+
+    if not files:
+        rprint("[yellow]No convention files found.[/]", file=sys.stderr)
+        raise typer.Exit(code=0)
+
+    for f in files:
+        words = len(f.read_text(errors="replace").split())
+        print(f"{f}\t{words} words")
+
+
+@app.command()
+def get_branch(
+    base: Annotated[
+        str,
+        typer.Option(
+            "--base",
+            "-b",
+            help="Base branch to diff against. Auto-detected from origin/HEAD if omitted.",
+        ),
+    ] = "",
+) -> None:
+    """Print the diff between the current branch and the base branch.
+
+    Auto-detects the default branch (main / master / develop) when --base is not
+    provided by inspecting origin/HEAD and then trying common branch names.
+    """
+    if not base:
+        ref, _ = _git("symbolic-ref", "refs/remotes/origin/HEAD")
+        if ref:
+            base = ref.replace("refs/remotes/origin/", "")
+
+    if not base:
+        for candidate in ("main", "master", "develop"):
+            _, rc = _git("rev-parse", "--verify", f"origin/{candidate}")
+            if rc == 0:
+                base = candidate
+                break
+
+    if not base:
+        rprint(
+            "[bold red]Error:[/] Could not detect default branch. "
+            "Set 'origin/HEAD' or pass --base explicitly.",
+            file=sys.stderr,
+        )
+        raise typer.Exit(code=1)
+
+    diff, _ = _git("diff", f"origin/{base}...HEAD", "-U5")
+    if not diff:
+        rprint(
+            f"[bold red]Error:[/] No changes between current branch and origin/{base}.",
+            file=sys.stderr,
+        )
+        raise typer.Exit(code=1)
+
+    print(diff)
+
+
+@app.command()
+def get_staged() -> None:
+    """Print the diff of staged (index) changes."""
+    diff, _ = _git("diff", "--staged", "-U5")
+    if not diff:
+        rprint(
+            "[bold red]Error:[/] No staged changes. Run 'git add' first.",
+            file=sys.stderr,
+        )
+        raise typer.Exit(code=1)
+
+    print(diff)
+
+
+@app.command()
+def get_working() -> None:
+    """Print the diff of working tree changes (unstaged)."""
+    diff, _ = _git("diff", "HEAD", "-U5")
+    if not diff:
+        rprint(
+            "[bold red]Error:[/] No working tree changes (nothing differs from HEAD).",
+            file=sys.stderr,
+        )
+        raise typer.Exit(code=1)
+
+    print(diff)
+
+
+if __name__ == "__main__":
+    app()

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
+        "@opencode-ai/sdk": "^1.17.15",
         "commander": "^12.1.0",
         "js-yaml": "^4.1.1"
       },
@@ -26,6 +27,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/darkrishabh"
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.17.15",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.15.tgz",
+      "integrity": "sha512-gWRQOEggHTELJ9+BtelxnuAczk9qutCXVZenPgRPaT8oVxePf52jfWbqfhyFjnrN8Vlp8tCCTdkEpFW5pZAuEA==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
       }
     },
     "node_modules/@types/js-yaml": {
@@ -60,6 +70,26 @@
         "node": ">=18"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -70,6 +100,36 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/typescript": {
@@ -92,6 +152,21 @@
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
       "import": "./dist/openai-compatible-provider.js",
       "types": "./dist/openai-compatible-provider.d.ts"
     },
+    "./opencode": {
+      "import": "./dist/opencode-provider.js",
+      "types": "./dist/opencode-provider.d.ts"
+    },
     "./config": {
       "import": "./dist/config.js",
       "types": "./dist/config.d.ts"
@@ -103,6 +107,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@opencode-ai/sdk": "^1.17.15",
     "commander": "^12.1.0",
     "js-yaml": "^4.1.1"
   },

--- a/scripts/run-quick-review-eval.sh
+++ b/scripts/run-quick-review-eval.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Runs the quick-review eval correctly:
+#   1. builds dist/ (opencode-provider.ts etc. need compiling)
+#   2. (re)builds the fixture repo the opencode agent will act on
+#   3. runs the CLI with the quick-review config, which pins
+#      runMode: opencode, opencode.dir at the fixture repo, opencode.auto,
+#      target, and concurrency: 1
+set -e
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+npm run build
+
+uv run examples/quick-review/evals/setup_fixture.py
+
+node dist/cli.js --config examples/agent-skills-eval.quick-review.yaml

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "skill-creator": {
+      "source": "anthropics/skills",
+      "sourceType": "github",
+      "skillPath": "skills/skill-creator/SKILL.md",
+      "computedHash": "5ea13a6d9f0d4bb694405d79acd00cadec0d21bb138c4dd10fcf3c500cb835c2"
+    }
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,8 @@ import { consoleReporter } from "./console-reporter.js";
 import { evaluateSkills } from "./evaluate-skills.js";
 import { jsonlReporter, type JsonlReporter } from "./jsonl-reporter.js";
 import { OpenAICompatibleProvider } from "./openai-compatible-provider.js";
+import { OpencodeProvider } from "./opencode-provider.js";
+import type { Provider } from "./provider.js";
 
 interface CliOptions {
   config?: string;
@@ -14,6 +16,12 @@ interface CliOptions {
   judge?: string;
   baseUrl?: string;
   apiKeyEnv?: string;
+  runMode?: "api" | "opencode";
+  opencodeAgent?: string;
+  opencodeAuto?: boolean;
+  opencodeDir?: string;
+  opencodeTimeout?: string;
+  opencodeJudgeTimeout?: string;
   include?: string[];
   exclude?: string[];
   concurrency?: string;
@@ -46,6 +54,16 @@ function reportOutput(report: AgentSkillsEvalConfig["report"]): string | undefin
   return typeof report === "object" && report ? report.output : undefined;
 }
 
+function requireApiCredentials(
+  baseUrl: string | undefined,
+  apiKey: string | undefined,
+  apiKeyEnv: string
+): { baseUrl: string; apiKey: string } {
+  if (!baseUrl) throw new Error("provide --base-url or set OPENAI_BASE_URL");
+  if (!apiKey) throw new Error(`environment variable ${apiKeyEnv} is not set`);
+  return { baseUrl, apiKey };
+}
+
 async function main(): Promise<void> {
   const program = new Command();
   program
@@ -59,6 +77,16 @@ async function main(): Promise<void> {
     .option("--judge <model>", "Judge model name; defaults to --target")
     .option("--base-url <url>", "OpenAI-compatible API base URL")
     .option("--api-key-env <name>", "Environment variable containing the API key")
+    .option("--run-mode <mode>", "Execution mode: api (default) or opencode")
+    .option("--opencode-agent <name>", "opencode --agent to use")
+    .option("--opencode-auto", "Auto-approve opencode permissions (dangerous)")
+    .option("--no-opencode-auto", "Disable opencode auto-approve, overriding config file")
+    .option("--opencode-dir <path>", "Working directory for opencode runs")
+    .option("--opencode-timeout <ms>", "opencode subprocess timeout in milliseconds")
+    .option(
+      "--opencode-judge-timeout <ms>",
+      "opencode judge/grader subprocess timeout in milliseconds; defaults to --opencode-timeout"
+    )
     .option("--include <glob>", "Include skill relPath glob", list, [])
     .option("--exclude <glob>", "Exclude skill relPath glob", list, [])
     .option("--concurrency <number>", "Eval cases to run in parallel")
@@ -83,6 +111,7 @@ async function main(): Promise<void> {
   const apiKeyEnv = opts.apiKeyEnv ?? config.apiKeyEnv ?? "OPENAI_API_KEY";
   const baseUrl = opts.baseUrl ?? config.baseUrl ?? process.env.OPENAI_BASE_URL;
   const apiKey = process.env[apiKeyEnv];
+  const runMode = opts.runMode ?? config.runMode ?? "api";
   const include = opts.include && opts.include.length > 0 ? opts.include : config.include;
   const exclude = opts.exclude && opts.exclude.length > 0 ? opts.exclude : config.exclude;
   const concurrency = opts.concurrency !== undefined
@@ -97,12 +126,34 @@ async function main(): Promise<void> {
   const logFile = opts.logFile ?? config.logging?.file;
   const verbose = opts.verbose ?? config.logging?.verbose ?? false;
   const color = opts.color ?? config.logging?.color ?? "auto";
+  const opencodeAgent = opts.opencodeAgent ?? config.opencode?.agent;
+  const opencodeBaseUrl = config.opencode?.baseUrl;
+  const opencodeAuto = opts.opencodeAuto ?? config.opencode?.auto ?? false;
+  const opencodeDir = opts.opencodeDir ?? config.opencode?.dir ?? process.cwd();
+  const opencodeTimeoutMs =
+    opts.opencodeTimeout !== undefined
+      ? Number.parseInt(opts.opencodeTimeout, 10)
+      : config.opencode?.timeoutMs ?? 5 * 60 * 1000;
+  const opencodeJudgeTimeoutMs =
+    opts.opencodeJudgeTimeout !== undefined
+      ? Number.parseInt(opts.opencodeJudgeTimeout, 10)
+      : config.opencode?.judgeTimeoutMs ?? opencodeTimeoutMs;
 
-  if (!baseUrl) {
-    throw new Error("provide --base-url or set OPENAI_BASE_URL");
+  if (runMode !== "api" && runMode !== "opencode") {
+    throw new Error('--run-mode must be "api" or "opencode"');
   }
-  if (!apiKey) {
-    throw new Error(`environment variable ${apiKeyEnv} is not set`);
+  if (runMode === "api") {
+    if (!baseUrl) {
+      throw new Error("provide --base-url or set OPENAI_BASE_URL");
+    }
+    if (!apiKey) {
+      throw new Error(`environment variable ${apiKeyEnv} is not set`);
+    }
+  }
+  if (runMode === "opencode" && !opts.target && !config.target) {
+    throw new Error(
+      '--target is required when --run-mode is "opencode" (use "provider/model", e.g. "anthropic/claude-sonnet-5")'
+    );
   }
   if (layout !== "iteration" && layout !== "flat") {
     throw new Error('--layout must be "iteration" or "flat"');
@@ -113,19 +164,49 @@ async function main(): Promise<void> {
   if (logFormat !== "pretty" && logFormat !== "jsonl" && logFormat !== "silent") {
     throw new Error('--log-format must be "pretty", "jsonl", or "silent"');
   }
+  if (runMode === "opencode" && (!Number.isInteger(opencodeTimeoutMs) || opencodeTimeoutMs < 1)) {
+    throw new Error("--opencode-timeout must be a positive integer (milliseconds)");
+  }
+  if (runMode === "opencode" && (!Number.isInteger(opencodeJudgeTimeoutMs) || opencodeJudgeTimeoutMs < 1)) {
+    throw new Error("--opencode-judge-timeout must be a positive integer (milliseconds)");
+  }
 
-  const target = new OpenAICompatibleProvider({
-    providerName: "openai-compatible",
-    baseUrl,
-    apiKey,
-    model: targetModel,
-  });
-  const judge = new OpenAICompatibleProvider({
-    providerName: "openai-compatible",
-    baseUrl,
-    apiKey,
-    model: judgeModel,
-  });
+  let target: Provider;
+  let judge: Provider;
+  if (runMode === "opencode") {
+    target = new OpencodeProvider({
+      providerName: "opencode",
+      model: targetModel,
+      agent: opencodeAgent,
+      dir: opencodeDir,
+      auto: opencodeAuto,
+      timeoutMs: opencodeTimeoutMs,
+      baseUrl: opencodeBaseUrl,
+    });
+    judge = new OpencodeProvider({
+      providerName: "opencode",
+      model: judgeModel,
+      agent: opencodeAgent,
+      dir: opencodeDir,
+      auto: opencodeAuto,
+      timeoutMs: opencodeJudgeTimeoutMs,
+      baseUrl: opencodeBaseUrl,
+    });
+  } else {
+    const creds = requireApiCredentials(baseUrl, apiKey, apiKeyEnv);
+    target = new OpenAICompatibleProvider({
+      providerName: "openai-compatible",
+      baseUrl: creds.baseUrl,
+      apiKey: creds.apiKey,
+      model: targetModel,
+    });
+    judge = new OpenAICompatibleProvider({
+      providerName: "openai-compatible",
+      baseUrl: creds.baseUrl,
+      apiKey: creds.apiKey,
+      model: judgeModel,
+    });
+  }
 
   let closeReporter: (() => Promise<void>) | undefined;
   let onEvent;

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,18 @@ import { load } from "js-yaml";
 
 export type LogFormat = "pretty" | "jsonl" | "silent";
 export type WorkspaceLayout = "flat" | "iteration";
+export type ProviderRunMode = "api" | "opencode";
+
+export interface OpencodeConfig {
+  agent?: string;
+  auto?: boolean;
+  dir?: string;
+  timeoutMs?: number;
+  /** Timeout for judge/grader calls. Defaults to `timeoutMs`. Judge sessions read a full transcript plus output files and are often slower than the executor run they grade. */
+  judgeTimeoutMs?: number;
+  /** Talk to an already-running `opencode serve` instead of spawning one. Mainly for tests, but also useful to share one server across multiple invocations. */
+  baseUrl?: string;
+}
 
 export interface AgentSkillsEvalConfig {
   root?: string;
@@ -13,6 +25,8 @@ export interface AgentSkillsEvalConfig {
   judge?: string;
   baseUrl?: string;
   apiKeyEnv?: string;
+  runMode?: ProviderRunMode;
+  opencode?: OpencodeConfig;
   include?: string[];
   exclude?: string[];
   concurrency?: number;
@@ -85,6 +99,25 @@ function parseLogFormat(value: unknown): LogFormat | undefined {
   throw new Error('logging.format must be "pretty", "jsonl", or "silent"');
 }
 
+function parseRunMode(value: unknown): ProviderRunMode | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (value === "api" || value === "opencode") return value;
+  throw new Error('runMode must be "api" or "opencode"');
+}
+
+function parseOpencode(value: unknown): OpencodeConfig | undefined {
+  if (value === undefined || value === null) return undefined;
+  const record = asRecord(value, "opencode");
+  return {
+    agent: asString(record.agent, "opencode.agent"),
+    auto: asBoolean(record.auto, "opencode.auto"),
+    dir: asString(record.dir, "opencode.dir"),
+    timeoutMs: asNumber(record.timeoutMs, "opencode.timeoutMs"),
+    judgeTimeoutMs: asNumber(record.judgeTimeoutMs, "opencode.judgeTimeoutMs"),
+    baseUrl: asString(record.baseUrl, "opencode.baseUrl"),
+  };
+}
+
 function parseReport(value: unknown): AgentSkillsEvalConfig["report"] {
   if (value === undefined || value === null) return undefined;
   if (typeof value === "boolean") return value;
@@ -122,6 +155,8 @@ export function normalizeConfig(raw: unknown): AgentSkillsEvalConfig {
     judge: asString(record.judge, "judge"),
     baseUrl: asString(record.baseUrl, "baseUrl"),
     apiKeyEnv: asString(record.apiKeyEnv, "apiKeyEnv"),
+    runMode: parseRunMode(record.runMode),
+    opencode: parseOpencode(record.opencode),
     include: asStringArray(record.include, "include"),
     exclude: asStringArray(record.exclude, "exclude"),
     concurrency: asNumber(record.concurrency, "concurrency"),

--- a/src/evaluate-skills.ts
+++ b/src/evaluate-skills.ts
@@ -154,6 +154,15 @@ export async function evaluateSkills(args: EvaluateSkillsArgs): Promise<Evaluate
 
   const concurrency = Math.max(1, args.concurrency ?? 4);
 
+  // Providers such as OpencodeProvider have no mapping between their own
+  // internal tool use and this SDK's tool_assertions feature, so those
+  // assertions always grade against an empty tool-call list. Warn once so
+  // failures aren't mistaken for model regressions (see README caveats).
+  const supportsToolAssertions =
+    args.target.provider.capabilities?.toolCalls !== false &&
+    args.judge.provider.capabilities?.toolCalls !== false;
+  let warnedToolAssertions = false;
+
   // ─── Phase 1: sequential discovery prep ───────────────────────────────────
   // Allocate skillDir + write meta.json + emit suite-start in discovery order
   // so the start-of-run banner is stable run-to-run regardless of pool size.
@@ -161,6 +170,16 @@ export async function evaluateSkills(args: EvaluateSkillsArgs): Promise<Evaluate
   for (const ref of refs) {
     args.onLog?.(`skill ${ref.name}: loading ${ref.relPath}`);
     const skill = loadSkill(ref.dir, { strict: args.strict });
+    if (
+      !supportsToolAssertions &&
+      !warnedToolAssertions &&
+      skill.evals.some((e) => e.tool_assertions && e.tool_assertions.length > 0)
+    ) {
+      process.stderr.write(
+        "warning: tool_assertions are not supported by the current provider and will always grade against an empty tool-call list (e.g. --run-mode opencode) — see README \"opencode run mode\" caveats.\n"
+      );
+      warnedToolAssertions = true;
+    }
     const slug = slugify(skill.name);
     const skillDir =
       workspaceLayout === "flat"

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,9 +23,16 @@ export type { GradeOutputsArgs, GradeOutputsResult } from "./grade.js";
 export type { RunEvalArgs, RunEvalResult } from "./run-eval.js";
 export type { ConsoleReporterOptions } from "./console-reporter.js";
 export type { GenerateReportArgs, GenerateReportResult } from "./report.js";
-export type { AgentSkillsEvalConfig, LogFormat, WorkspaceLayout } from "./config.js";
+export type {
+  AgentSkillsEvalConfig,
+  LogFormat,
+  OpencodeConfig,
+  ProviderRunMode,
+  WorkspaceLayout,
+} from "./config.js";
 export type { JsonlReporter, JsonlReporterOptions } from "./jsonl-reporter.js";
 export type { OpenAICompatibleOptions } from "./openai-compatible-provider.js";
+export type { OpencodeOptions } from "./opencode-provider.js";
 export type { RunPrompts } from "./artifacts.js";
 export type {
   CompleteChatArgs,
@@ -50,6 +57,7 @@ export { gradeOutputs, runToolAssertions } from "./grade.js";
 export { jsonlReporter } from "./jsonl-reporter.js";
 export { loadConfigFile, normalizeConfig } from "./config.js";
 export { OpenAICompatibleProvider } from "./openai-compatible-provider.js";
+export { OpencodeProvider } from "./opencode-provider.js";
 export { runEval } from "./run-eval.js";
 export { loadSkill } from "./skill.js";
 export { createStaticProvider } from "./provider.js";

--- a/src/opencode-provider.ts
+++ b/src/opencode-provider.ts
@@ -1,0 +1,530 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { mkdirSync, readdirSync, rmSync, symlinkSync } from "node:fs";
+import path from "node:path";
+import { createOpencodeClient } from "@opencode-ai/sdk";
+import type { AssistantMessage, Message, Part } from "@opencode-ai/sdk";
+import type { Provider, ProviderResult, SkillSource, ToolCall } from "./provider.js";
+
+export interface OpencodeOptions {
+  /** Shown as `provider` in ProviderResult. Default "opencode". */
+  providerName?: string;
+  /** Required. "provider/model" form, e.g. "anthropic/claude-sonnet-5". */
+  model: string;
+  /** Forwarded as the session's `agent`. Omitted when unset. */
+  agent?: string;
+  /** Working directory for the opencode server and installed skills. Default process.cwd(). */
+  dir?: string;
+  /** Auto-approve opencode's own permission prompts (bash/file-edit/etc). Dangerous — see class doc comment. Default false. */
+  auto?: boolean;
+  /** Hard deadline for the whole call (initial prompt + waiting on delegated work + continuations), ms. Default 300_000 (5 minutes). */
+  timeoutMs?: number;
+  /** Max follow-up prompts issued to let the model pick up a delegated subagent's result. Default 3. */
+  maxContinuations?: number;
+  /** Test-only: talk to an already-running server instead of spawning one via `createOpencodeServer`. */
+  baseUrl?: string;
+}
+
+interface RunOutcome {
+  text: string;
+  toolCalls: ToolCall[];
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  errorMessage?: string;
+}
+
+const POLL_INTERVAL_MS = 250;
+/** Grace period between SIGTERM and SIGKILL when tearing down our private opencode server. */
+const SERVER_KILL_GRACE_MS = 3000;
+/** How long to wait for `opencode serve` to print its listening URL before giving up. */
+const SERVER_START_TIMEOUT_MS = 10_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+interface SpawnedServer {
+  url: string;
+  close(): void;
+  /** Combined stdout+stderr of the child process so far, including everything logged after startup. */
+  getLog(): string;
+}
+
+/**
+ * Spawns `opencode serve` directly (rather than via `@opencode-ai/sdk`'s
+ * `createOpencodeServer`) so we keep a handle to the raw child process and
+ * can escalate to SIGKILL if it doesn't honor SIGTERM promptly — the SDK
+ * helper's `close()` only ever sends one SIGTERM with no escalation, which
+ * left real orphaned `opencode serve` processes behind in testing.
+ */
+function spawnOpencodeServer(options: {
+  hostname: string;
+  port: number;
+  permission?: Record<string, unknown>;
+}): Promise<SpawnedServer> {
+  return new Promise((resolve, reject) => {
+    const child: ChildProcess = spawn(
+      "opencode",
+      ["serve", `--hostname=${options.hostname}`, `--port=${options.port}`],
+      {
+        shell: false,
+        env: {
+          ...process.env,
+          OPENCODE_CONFIG_CONTENT: JSON.stringify(options.permission ? { permission: options.permission } : {}),
+        },
+      }
+    );
+
+    let settled = false;
+    let output = "";
+
+    const forceKill = () => {
+      child.kill("SIGTERM");
+      const killTimer = setTimeout(() => child.kill("SIGKILL"), SERVER_KILL_GRACE_MS);
+      killTimer.unref();
+    };
+
+    const startTimer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      forceKill();
+      reject(new Error(`Timeout waiting for opencode server to start after ${SERVER_START_TIMEOUT_MS}ms`));
+    }, SERVER_START_TIMEOUT_MS);
+    startTimer.unref();
+
+    child.stdout?.on("data", (chunk) => {
+      output += String(chunk);
+      if (settled) return;
+      const match = output.match(/opencode server listening on\s+(https?:\/\/\S+)/);
+      if (match) {
+        settled = true;
+        clearTimeout(startTimer);
+        resolve({ url: match[1], close: forceKill, getLog: () => output });
+      }
+    });
+    child.stderr?.on("data", (chunk) => {
+      output += String(chunk);
+    });
+    child.on("exit", (code) => {
+      clearTimeout(startTimer);
+      if (!settled) {
+        settled = true;
+        reject(new Error(`opencode serve exited with code ${code} before it started listening${output.trim() ? `: ${output.trim()}` : ""}`));
+      }
+    });
+    child.on("error", (err) => {
+      clearTimeout(startTimer);
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+    });
+  });
+}
+
+function splitModel(model: string): { providerID: string; modelID: string } {
+  const idx = model.indexOf("/");
+  if (idx === -1) {
+    throw new Error(`OpencodeProvider: model must be "provider/model" (e.g. "anthropic/claude-sonnet-5"), got "${model}"`);
+  }
+  return { providerID: model.slice(0, idx), modelID: model.slice(idx + 1) };
+}
+
+/** Best-effort message from an SDK error body (parsed JSON, not necessarily an Error instance). */
+function describeError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (error && typeof error === "object") {
+    const obj = error as { data?: { message?: unknown }; message?: unknown; name?: unknown };
+    if (typeof obj.data?.message === "string") return obj.data.message;
+    if (typeof obj.message === "string") return obj.message;
+    if (typeof obj.name === "string") return obj.name;
+  }
+  return "opencode server request failed";
+}
+
+function isTextPart(part: Part): part is Extract<Part, { type: "text" }> {
+  return part.type === "text";
+}
+
+function isToolPart(part: Part): part is Extract<Part, { type: "tool" }> {
+  return part.type === "tool";
+}
+
+function toolCallFrom(part: Extract<Part, { type: "tool" }>): ToolCall {
+  const input = part.state.input;
+  return {
+    id: part.callID,
+    type: "function",
+    function: { name: part.tool, arguments: JSON.stringify(input) },
+    parsedArguments: input,
+  };
+}
+
+/**
+ * Sums token/cost usage across every assistant message in the session (each
+ * internal tool-calling "step" opencode takes gets its own message record).
+ * Tool calls are likewise gathered from every assistant message, since "was
+ * a tool ever called this run" shouldn't depend on which step it happened
+ * in. Text, however, is gathered only from the assistant messages belonging
+ * to the last *answered* turn — a turn's closing step can be a text-less
+ * tool call (e.g. a trailing todo-list update) even though an earlier step
+ * already delivered the real answer, so taking text from every message
+ * risks concatenating in stale content from a superseded earlier turn, and
+ * taking it only from the very last message risks losing the answer
+ * entirely. This also has to tolerate being called while the session's
+ * last message is itself an unanswered notification (the "gave up after N
+ * follow-ups" path) — in that case the real content is the turn *before*
+ * that trailing notification, not nothing.
+ */
+function collectOutcome(messages: Array<{ info: Message; parts: Part[] }>): RunOutcome {
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let costUsd = 0;
+  let lastAssistant: AssistantMessage | undefined;
+  const toolCalls: ToolCall[] = [];
+
+  for (const entry of messages) {
+    if (entry.info.role !== "assistant") continue;
+    const info = entry.info;
+    inputTokens += info.tokens?.input ?? 0;
+    outputTokens += (info.tokens?.output ?? 0) + (info.tokens?.reasoning ?? 0);
+    costUsd += info.cost ?? 0;
+    lastAssistant = info;
+    toolCalls.push(...entry.parts.filter(isToolPart).map(toolCallFrom));
+  }
+
+  // Find the boundary of the last *answered* turn: scanning from the end,
+  // skip over a trailing user message that has no assistant reply yet (an
+  // unanswered delegation notification — the "gave up after N follow-ups"
+  // path calls this while one is still sitting unanswered) and keep looking
+  // until we hit a user message that assistant messages actually followed.
+  let boundary = -1;
+  let sawAssistant = false;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const role = messages[i].info.role;
+    if (role === "assistant") {
+      sawAssistant = true;
+      continue;
+    }
+    if (role === "user" && sawAssistant) {
+      boundary = i;
+      break;
+    }
+  }
+  const text = messages
+    .slice(boundary + 1)
+    .filter((entry) => entry.info.role === "assistant")
+    .flatMap((entry) => entry.parts)
+    .filter(isTextPart)
+    .map((p) => p.text)
+    .join("");
+
+  let errorMessage = lastAssistant?.error ? describeError(lastAssistant.error) : undefined;
+  if (!text && !errorMessage) {
+    errorMessage = `opencode run completed with ${toolCalls.length} tool call(s) but produced no text output`;
+  }
+  return { text, toolCalls, inputTokens, outputTokens, costUsd, errorMessage };
+}
+
+/** Tool names opencode exposes for dispatching a delegated subagent. */
+const DELEGATION_DISPATCH_TOOLS = new Set(["delegate", "task"]);
+/** Tool name opencode exposes for reading back a dispatched delegation's result. */
+const DELEGATION_READ_TOOLS = new Set(["delegation_read"]);
+/**
+ * Below this length, a reply that hasn't read back every dispatched
+ * delegation is treated as a premature "waiting on delegation" stub rather
+ * than a real (if short) answer — see `isStalledOnDelegation`.
+ */
+const STUB_TEXT_THRESHOLD = 300;
+
+/**
+ * True when the model has dispatched more delegations (`delegate`/`task`)
+ * than it has read back (`delegation_read`) and its reply so far is too
+ * short to plausibly be a real synthesis of that work. Catches the case
+ * where the model narrates something like "Waiting for delegation
+ * result..." and ends its turn instead of polling `delegation_read` or
+ * letting the harness's own continuation loop pick the result up — that
+ * text is the model's own reply (not opencode's unanswered-notification
+ * message), so without this check it looks structurally identical to a
+ * real final answer and gets accepted as one.
+ */
+function isStalledOnDelegation(outcome: RunOutcome): boolean {
+  const dispatched = outcome.toolCalls.filter((call) => DELEGATION_DISPATCH_TOOLS.has(call.function.name)).length;
+  const read = outcome.toolCalls.filter((call) => DELEGATION_READ_TOOLS.has(call.function.name)).length;
+  return dispatched > read && outcome.text.trim().length < STUB_TEXT_THRESHOLD;
+}
+
+/**
+ * Wraps opencode's HTTP server (via `@opencode-ai/sdk`'s client, talking to
+ * our own directly-spawned `opencode serve` process) as a `Provider`. Each
+ * `complete()` call spawns a fresh server (auto-assigned port so concurrent
+ * calls don't collide), creates one session, sends the prompt, and waits.
+ *
+ * opencode's own subagent delegation (the `delegate`/`task` tool — see
+ * https://opencode.ai/docs/agents/) is asynchronous: the model's own turn
+ * ends the moment it dispatches a delegation, well before the delegate
+ * finishes, and the delegate's result is delivered later as a message
+ * appended to the same session. A one-shot request/response cycle can't
+ * wait for that, so this provider keeps the server alive after the initial
+ * prompt resolves and polls `session.status`/`session.children` until every
+ * delegated child session goes idle, then — if the session's last message is
+ * still an unanswered notification rather than the model's own reply, or the
+ * model's own reply is a premature "waiting on delegation" stub that never
+ * read back a dispatched delegation's result (see `isStalledOnDelegation`) —
+ * sends a bounded number of follow-up prompts (`maxContinuations`) so the
+ * model can actually synthesize using the delegate's result. All of this is
+ * bounded by `timeoutMs` as the overall deadline.
+ *
+ * Implements `prepareSkill`/`cleanupSkill`: rather than injecting the skill
+ * into the prompt, it symlinks every entry of the skill's directory (except
+ * `evals/`, which holds the answer key) into `<dir>/.opencode/skills/<name>/`
+ * so opencode's own skill tool discovers and loads it exactly as it would in
+ * real-world use (see https://opencode.ai/docs/skills/). `runEval` calls
+ * this instead of building a system message whenever the provider exposes
+ * these hooks.
+ *
+ * Caveats (see README "opencode run mode" for detail): token/cost numbers
+ * include opencode's own system-prompt/tool-schema overhead and are not
+ * comparable to raw chat-completion counts from OpenAICompatibleProvider for
+ * the same model; `auto: true` auto-approves opencode's own permission
+ * prompts (bash/file-edit tools) unattended and is off by default;
+ * capabilities are all false, so callers always merge system+user into one
+ * string before calling `complete()`. The installed skill directory is
+ * shared across every call using the same `dir` — use `--concurrency 1` if
+ * concurrent evals of the same skill would otherwise race on install/remove.
+ */
+export class OpencodeProvider implements Provider {
+  readonly capabilities = { systemRole: false, attachments: false, toolCalls: false };
+  readonly name: string;
+  readonly model: string;
+  private agent?: string;
+  private dir: string;
+  private auto: boolean;
+  private timeoutMs: number;
+  private maxContinuations: number;
+  private baseUrl?: string;
+
+  constructor(options: OpencodeOptions) {
+    if (!options.model) {
+      throw new Error('OpencodeProvider requires "model" (e.g. "anthropic/claude-sonnet-5")');
+    }
+    this.name = options.providerName ?? "opencode";
+    this.model = options.model;
+    this.agent = options.agent;
+    this.dir = options.dir ?? process.cwd();
+    this.auto = options.auto ?? false;
+    this.timeoutMs = options.timeoutMs ?? 5 * 60 * 1000;
+    this.maxContinuations = options.maxContinuations ?? 3;
+    this.baseUrl = options.baseUrl;
+  }
+
+  /**
+   * Removes any previously installed copy of `skill`, then — only when
+   * `mode` is `"with_skill"` — symlinks it into place so opencode's skill
+   * tool finds it under `<dir>/.opencode/skills/<name>/`. Every entry in
+   * `skill.dir` is linked except `evals/`, which holds the answer key.
+   */
+  async prepareSkill(skill: SkillSource, mode: "with_skill" | "without_skill"): Promise<void> {
+    const installDir = this.skillInstallDir(skill.name);
+    rmSync(installDir, { recursive: true, force: true });
+    if (mode !== "with_skill") return;
+
+    mkdirSync(installDir, { recursive: true });
+    for (const entry of readdirSync(skill.dir, { withFileTypes: true })) {
+      if (entry.name === "evals") continue;
+      symlinkSync(
+        path.join(skill.dir, entry.name),
+        path.join(installDir, entry.name),
+        entry.isDirectory() ? "dir" : "file"
+      );
+    }
+  }
+
+  /** Removes whatever `prepareSkill` installed for `skill`, regardless of mode. */
+  async cleanupSkill(skill: SkillSource): Promise<void> {
+    rmSync(this.skillInstallDir(skill.name), { recursive: true, force: true });
+  }
+
+  private skillInstallDir(name: string): string {
+    return path.join(this.dir, ".opencode", "skills", name);
+  }
+
+  async complete(prompt: string): Promise<ProviderResult> {
+    const start = Date.now();
+    const deadline = start + this.timeoutMs;
+    let server: SpawnedServer | undefined;
+
+    try {
+      let baseUrl = this.baseUrl;
+      if (!baseUrl) {
+        server = await spawnOpencodeServer({
+          hostname: "127.0.0.1",
+          port: 0,
+          permission: this.auto
+            ? { edit: "allow", bash: "allow", webfetch: "allow", doom_loop: "allow", external_directory: "allow" }
+            : undefined,
+        });
+        baseUrl = server.url;
+      }
+
+      const client = createOpencodeClient({ baseUrl, directory: this.dir });
+      const outcome = await this.runSession(client, prompt, deadline);
+      const latencyMs = Date.now() - start;
+
+      if (outcome.errorMessage) {
+        return this.withServerLog(this.errorResult(outcome.errorMessage, latencyMs, outcome), server);
+      }
+      return this.withServerLog(
+        {
+          provider: this.name,
+          model: this.model,
+          output: outcome.text,
+          latencyMs,
+          inputTokens: outcome.inputTokens,
+          outputTokens: outcome.outputTokens,
+          costUsd: outcome.costUsd,
+          toolCalls: outcome.toolCalls,
+        },
+        server
+      );
+    } catch (err) {
+      return this.withServerLog(
+        {
+          provider: this.name,
+          model: this.model,
+          output: "",
+          latencyMs: Date.now() - start,
+          inputTokens: 0,
+          outputTokens: 0,
+          costUsd: 0,
+          error: err instanceof Error ? err.message : String(err),
+        },
+        server
+      );
+    } finally {
+      server?.close();
+    }
+  }
+
+  private errorResult(message: string, latencyMs: number, outcome: RunOutcome): ProviderResult {
+    return {
+      provider: this.name,
+      model: this.model,
+      output: outcome.text,
+      latencyMs,
+      inputTokens: outcome.inputTokens,
+      outputTokens: outcome.outputTokens,
+      costUsd: outcome.costUsd,
+      toolCalls: outcome.toolCalls,
+      error: message,
+    };
+  }
+
+  /** Attaches the spawned server's combined stdout+stderr as a debug artifact, when we actually spawned one (not when talking to an external `baseUrl`). */
+  private withServerLog(result: ProviderResult, server: SpawnedServer | undefined): ProviderResult {
+    if (!server) return result;
+    return { ...result, outputFiles: [{ path: "opencode-serve.log", content: server.getLog() }] };
+  }
+
+  private async runSession(
+    client: ReturnType<typeof createOpencodeClient>,
+    prompt: string,
+    deadline: number
+  ): Promise<RunOutcome> {
+    const model = splitModel(this.model);
+
+    const created = await client.session.create({ signal: this.remainingSignal(deadline) });
+    if (created.error) {
+      return { text: "", toolCalls: [], inputTokens: 0, outputTokens: 0, costUsd: 0, errorMessage: describeError(created.error) };
+    }
+    const sessionId = created.data.id;
+
+    const sendPrompt = (text: string) =>
+      client.session.prompt({
+        path: { id: sessionId },
+        body: { agent: this.agent, model, parts: [{ type: "text", text }] },
+        signal: this.remainingSignal(deadline),
+      });
+
+    const first = await sendPrompt(prompt);
+    if (first.error) {
+      return { text: "", toolCalls: [], inputTokens: 0, outputTokens: 0, costUsd: 0, errorMessage: describeError(first.error) };
+    }
+
+    let continuations = 0;
+    while (true) {
+      const idle = await this.waitForIdle(client, sessionId, deadline);
+      if (!idle) {
+        return {
+          text: "",
+          toolCalls: [],
+          inputTokens: 0,
+          outputTokens: 0,
+          costUsd: 0,
+          errorMessage: `opencode run timed out after ${this.timeoutMs}ms waiting for delegated work to finish`,
+        };
+      }
+
+      const messagesResult = await client.session.messages({
+        path: { id: sessionId },
+        signal: this.remainingSignal(deadline),
+      });
+      if (messagesResult.error) {
+        return { text: "", toolCalls: [], inputTokens: 0, outputTokens: 0, costUsd: 0, errorMessage: describeError(messagesResult.error) };
+      }
+      const messages = messagesResult.data;
+      const lastMessage = messages[messages.length - 1];
+      const outcome = collectOutcome(messages);
+      const stalled = lastMessage?.info.role !== "user" && isStalledOnDelegation(outcome);
+
+      // The model's own reply (not a still-unanswered notification, and not
+      // a premature "waiting on delegation" stub) is the real end of the turn.
+      if (lastMessage?.info.role !== "user" && !stalled) {
+        return outcome;
+      }
+
+      if (continuations >= this.maxContinuations || Date.now() >= deadline) {
+        return {
+          ...outcome,
+          errorMessage: stalled
+            ? `opencode run: gave up after ${continuations} follow-up prompt(s) waiting for the model to read back a dispatched delegation's result`
+            : `opencode run: gave up after ${continuations} follow-up prompt(s) waiting for the model to use a delegated subagent's result`,
+        };
+      }
+
+      continuations++;
+      const cont = await sendPrompt(
+        "Continue. If you dispatched a delegation, call delegation_read on its id now and report the findings — do not say you are waiting."
+      );
+      if (cont.error) {
+        return { text: "", toolCalls: [], inputTokens: 0, outputTokens: 0, costUsd: 0, errorMessage: describeError(cont.error) };
+      }
+    }
+  }
+
+  /** Polls until the session and every delegated child session report non-busy, or the deadline passes. */
+  private async waitForIdle(
+    client: ReturnType<typeof createOpencodeClient>,
+    sessionId: string,
+    deadline: number
+  ): Promise<boolean> {
+    while (true) {
+      const childrenResult = await client.session.children({ path: { id: sessionId }, signal: this.remainingSignal(deadline) });
+      const childIds = (childrenResult.data ?? []).map((session) => session.id);
+      const statusResult = await client.session.status({ signal: this.remainingSignal(deadline) });
+      const statusById = statusResult.data ?? {};
+
+      const allIdle = [sessionId, ...childIds].every((id) => {
+        const type = statusById[id]?.type ?? "idle";
+        return type !== "busy" && type !== "retry";
+      });
+      if (allIdle) return true;
+      if (Date.now() >= deadline) return false;
+      await sleep(Math.min(POLL_INTERVAL_MS, Math.max(0, deadline - Date.now())));
+    }
+  }
+
+  private remainingSignal(deadline: number): AbortSignal {
+    return AbortSignal.timeout(Math.max(0, deadline - Date.now()));
+  }
+}

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -40,6 +40,8 @@ export interface ProviderResult {
   costUsd: number;
   error?: string;
   toolCalls?: ToolCall[];
+  /** Provider-specific debug artifacts written alongside the run's other outputs (e.g. opencode's own server log). */
+  outputFiles?: { path: string; content: string | Buffer }[];
 }
 
 export interface CompleteChatArgs {
@@ -52,12 +54,31 @@ export interface CompleteChatArgs {
   params?: Record<string, unknown>;
 }
 
+/** Minimal shape `prepareSkill`/`cleanupSkill` need — satisfied structurally by `Skill`. */
+export interface SkillSource {
+  name: string;
+  /** Absolute path to the skill's folder on disk (contains SKILL.md, references/, scripts/, evals/). */
+  dir: string;
+}
+
 export interface Provider {
   readonly name: string;
   readonly model: string;
   readonly capabilities?: ProviderCapabilities;
   complete(prompt: string): Promise<ProviderResult>;
   completeChat?(args: CompleteChatArgs): Promise<ProviderResult>;
+  /**
+   * Make `skill` discoverable the way this provider's agent natively finds
+   * skills on disk (e.g. opencode's own skill-directory scan), instead of
+   * injecting its content into the prompt. Called before every `complete`/
+   * `completeChat` in `mode`; implementations should remove any previously
+   * installed skill first, then (re)install only when `mode` is
+   * `"with_skill"`. Providers that don't support native discovery should
+   * omit this — callers fall back to injecting the skill into the prompt.
+   */
+  prepareSkill?(skill: SkillSource, mode: "with_skill" | "without_skill"): Promise<void>;
+  /** Undo whatever `prepareSkill` installed, regardless of `mode`. */
+  cleanupSkill?(skill: SkillSource, mode: "with_skill" | "without_skill"): Promise<void>;
 }
 
 export function createStaticProvider(output: string, options: Partial<ProviderResult> = {}): Provider {

--- a/src/report.ts
+++ b/src/report.ts
@@ -293,16 +293,32 @@ function renderToolCallsPanel(calls: ToolCall[] | undefined): string {
   `;
 }
 
-function renderRun(run: ReportRun): string {
+/** Did a `with_skill` run's model actually call the `skill` tool for this skill? `undefined` when not applicable (without_skill mode, or no tool-call data captured). */
+function skillWasInvoked(run: ReportRun, skillName: string): boolean | undefined {
+  if (run.mode !== "with_skill" || !run.toolCalls) return undefined;
+  return run.toolCalls.some(
+    (c) => c.function.name === "skill" && (c.parsedArguments as Record<string, unknown> | undefined)?.name === skillName
+  );
+}
+
+function renderRun(run: ReportRun, skillName: string): string {
   const summary = run.grading.summary;
   const passed = summary.failed === 0 && summary.total > 0;
   const status = summary.total === 0 ? "n/a" : passed ? "PASS" : "FAIL";
   const statusCls = summary.total === 0 ? "muted" : passed ? "ok" : "bad";
+  const invoked = skillWasInvoked(run, skillName);
+  const invokedBadge =
+    invoked === undefined
+      ? ""
+      : invoked
+        ? `<span class="skill-invoked ok">skill picked up</span>`
+        : `<span class="skill-invoked bad">skill not picked up</span>`;
   return `
     <section class="run">
       <header class="run-head">
         <span class="mode mode-${run.mode}">${run.mode}</span>
         <span class="status ${statusCls}">${status}</span>
+        ${invokedBadge}
         <span class="muted">${ms(run.timing.duration_ms)} · ${run.timing.total_tokens} tokens · ${summary.passed}/${summary.total}</span>
       </header>
       ${
@@ -323,7 +339,7 @@ function renderRun(run: ReportRun): string {
   `;
 }
 
-function renderEval(ev: ReportEval): string {
+function renderEval(ev: ReportEval, skillName: string): string {
   const totalAssertions = ev.modes.reduce((sum, m) => sum + m.grading.summary.total, 0);
   const passedAssertions = ev.modes.reduce((sum, m) => sum + m.grading.summary.passed, 0);
   const allPassed = ev.modes.every((m) => m.grading.summary.failed === 0 && m.grading.summary.total > 0);
@@ -335,7 +351,7 @@ function renderEval(ev: ReportEval): string {
         <span class="eval-name">${escapeHtml(ev.slug)}</span>
         <span class="muted">${passedAssertions}/${totalAssertions} assertions</span>
       </summary>
-      <div class="eval-body">${ev.modes.map(renderRun).join("\n")}</div>
+      <div class="eval-body">${ev.modes.map((run) => renderRun(run, skillName)).join("\n")}</div>
     </details>
   `;
 }
@@ -359,7 +375,7 @@ function renderSkillSection(skill: ReportSkill): string {
         <div class="muted">${t.passed}/${t.total} assertions · ${skill.evals.length} evals · ${ms(t.avgDurationMs)} avg · ${Math.round(t.avgTokens)} tokens avg</div>
         ${benchmarkBlock}
       </header>
-      <div class="evals">${skill.evals.map(renderEval).join("\n")}</div>
+      <div class="evals">${skill.evals.map((ev) => renderEval(ev, skill.meta.name)).join("\n")}</div>
     </article>
   `;
 }
@@ -432,6 +448,9 @@ const STYLES = `
   .mode-without_skill { background: #fff1e5; color: #bc4c00; }
   .status.ok { color: var(--ok); font-weight: 600; }
   .status.bad { color: var(--bad); font-weight: 600; }
+  .skill-invoked { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 11px; font-weight: 500; }
+  .skill-invoked.ok { background: var(--ok-bg); color: var(--ok); }
+  .skill-invoked.bad { background: var(--bad-bg); color: var(--bad); }
   .run details > summary { cursor: pointer; font-size: 12px; color: var(--muted); padding: 4px 0; }
   .run details[open] > summary { color: var(--fg); }
   .run pre { background: var(--bg-alt); border: 1px solid var(--border); border-radius: 6px; padding: 10px 12px; font-family: var(--mono); font-size: 12px; line-height: 1.45; overflow-x: auto; white-space: pre-wrap; word-break: break-word; max-height: 400px; overflow-y: auto; }

--- a/src/run-eval.ts
+++ b/src/run-eval.ts
@@ -185,11 +185,20 @@ export async function runEval(args: RunEvalArgs): Promise<RunEvalResult> {
     args.skill.defaults?.judge?.params
   );
 
+  // If the target provider can natively discover skills on disk (e.g.
+  // opencode's own skill-directory scan), let it — don't also inject the
+  // skill into the prompt. `prepareSkill` installs/removes it per mode.
+  const nativeSkillLoading = typeof args.target.provider.prepareSkill === "function";
+
   for (const mode of args.modes) {
     const runDir = path.join(evalDir, mode);
     const outputDir = path.join(runDir, "outputs");
     const evalFiles = mode === "with_skill" ? readEvalFiles(args.skill, args.eval) : [];
-    const system = mode === "with_skill" ? renderSkillSystemMessage(args.skill) : undefined;
+    const system = nativeSkillLoading
+      ? undefined
+      : mode === "with_skill"
+        ? renderSkillSystemMessage(args.skill)
+        : undefined;
     const userMessage = args.eval.prompt;
 
     args.onEvent?.({
@@ -207,16 +216,25 @@ export async function runEval(args: RunEvalArgs): Promise<RunEvalResult> {
       toolChoice: effectiveToolChoice,
     });
 
-    const completion = await completeWithFallback({
-      provider: args.target.provider,
-      system,
-      user: userMessage,
-      attachments: evalFiles,
-      tools: effectiveTools,
-      toolChoice: effectiveToolChoice,
-      params: effectiveTargetParams,
-    });
-    const rawOutput = completion.error ? `ERROR: ${completion.error}` : completion.output;
+    if (nativeSkillLoading) await args.target.provider.prepareSkill!(args.skill, mode);
+    let completion: ProviderResult;
+    try {
+      completion = await completeWithFallback({
+        provider: args.target.provider,
+        system,
+        user: userMessage,
+        attachments: evalFiles,
+        tools: effectiveTools,
+        toolChoice: effectiveToolChoice,
+        params: effectiveTargetParams,
+      });
+    } finally {
+      if (nativeSkillLoading) await args.target.provider.cleanupSkill?.(args.skill, mode);
+    }
+    const rawOutput = completion.error
+      ? `ERROR: ${completion.error}` +
+        (completion.output ? `\n\n---partial output---\n${completion.output}` : "")
+      : completion.output;
     const toolCalls = completion.toolCalls;
     const assertions =
       args.eval.assertions && args.eval.assertions.length > 0
@@ -239,7 +257,7 @@ export async function runEval(args: RunEvalArgs): Promise<RunEvalResult> {
       timing,
       grading,
       rawOutput,
-      [{ path: "output.txt", content: rawOutput }],
+      completion.outputFiles ?? [],
       {
         system,
         user: userMessage,

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -6,6 +6,7 @@ import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
+import { createFakeOpencodeServer } from "./fixtures/fake-opencode-server.mjs";
 
 const execFileAsync = promisify(execFile);
 
@@ -138,4 +139,93 @@ test("CLI runs from YAML config and writes JSONL logs plus report artifacts", as
   } finally {
     await mock.close();
   }
+});
+
+test("CLI --run-mode opencode skips API credential requirements and runs via the opencode server", async () => {
+  const root = tempRoot();
+  writeSkill(root);
+  const workspace = path.join(root, "workspace");
+  const configPath = path.join(root, "agent-skills-eval.yaml");
+  const logFile = path.join(root, "events.jsonl");
+  const fakeServer = await createFakeOpencodeServer();
+
+  try {
+    writeFileSync(configPath, [
+      `root: ${JSON.stringify(root)}`,
+      `workspace: ${JSON.stringify(workspace)}`,
+      "baseline: true",
+      "target: fake/model",
+      "judge: fake/model",
+      "runMode: opencode",
+      "opencode:",
+      `  baseUrl: ${JSON.stringify(fakeServer.url)}`,
+      "  timeoutMs: 60000",
+      "  judgeTimeoutMs: 120000",
+      "layout: iteration",
+      "strict: true",
+      "report:",
+      "  enabled: false",
+      "logging:",
+      "  format: jsonl",
+      `  file: ${JSON.stringify(logFile)}`,
+    ].join("\n"));
+
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      ["dist/cli.js", "--config", configPath],
+      {
+        cwd: path.resolve("."),
+        env: { ...process.env, OPENAI_API_KEY: "", OPENAI_BASE_URL: "" },
+      },
+    );
+
+    const result = JSON.parse(stdout);
+    assert.equal(result.failed, 0);
+    assert.ok(existsSync(path.join(workspace, "iteration-1", "eval-top-month", "with_skill", "grading.json")));
+  } finally {
+    await fakeServer.close();
+  }
+});
+
+test("CLI --run-mode bogus fails validation with a clear error", async () => {
+  const root = tempRoot();
+  writeSkill(root);
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      ["dist/cli.js", root, "--run-mode", "bogus", "--target", "fake/model"],
+      { cwd: path.resolve(".") },
+    ),
+    (err) => {
+      assert.match(err.stderr, /--run-mode must be "api" or "opencode"/);
+      return true;
+    },
+  );
+});
+
+test("CLI --opencode-judge-timeout rejects non-positive values", async () => {
+  const root = tempRoot();
+  writeSkill(root);
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "dist/cli.js",
+        root,
+        "--run-mode",
+        "opencode",
+        "--target",
+        "fake/model",
+        "--opencode-judge-timeout",
+        "0",
+      ],
+      { cwd: path.resolve(".") },
+    ),
+    (err) => {
+      assert.match(err.stderr, /--opencode-judge-timeout must be a positive integer/);
+      return true;
+    },
+  );
 });

--- a/test/fixtures/fake-opencode-binary.mjs
+++ b/test/fixtures/fake-opencode-binary.mjs
@@ -1,0 +1,15 @@
+// Fake `opencode` CLI used to test OpencodeProvider's real spawn path
+// (`spawnOpencodeServer`) without a real opencode install. Reuses the fake
+// HTTP server fixture for request handling, then — after printing the
+// "listening" line the real CLI prints — writes a bit more to stdout/stderr,
+// mimicking the post-startup log chatter (tool calls, crashes, etc.) a real
+// `opencode serve` process would produce during a session.
+import { createFakeOpencodeServer } from "./fake-opencode-server.mjs";
+
+const server = await createFakeOpencodeServer();
+process.stdout.write(`opencode server listening on ${server.url}\n`);
+
+setTimeout(() => {
+  process.stdout.write("post-startup stdout line\n");
+  process.stderr.write("post-startup stderr line\n");
+}, 50);

--- a/test/fixtures/fake-opencode-server.mjs
+++ b/test/fixtures/fake-opencode-server.mjs
@@ -1,0 +1,372 @@
+// Fake opencode HTTP server for tests. Implements just the handful of
+// `@opencode-ai/sdk` endpoints OpencodeProvider calls (session create/prompt/
+// status/children/messages), scripted by marker strings in the prompt text,
+// mimicking the real server's shapes closely enough to exercise the
+// provider's polling/continuation logic without a real opencode install.
+import { createServer } from "node:http";
+
+const DELEGATE_SETTLE_MS = 300;
+
+function respondJson(res, status, body) {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(payload);
+}
+
+function readJsonBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk) => {
+      body += chunk;
+    });
+    req.on("end", () => {
+      if (!body) return resolve(undefined);
+      try {
+        resolve(JSON.parse(body));
+      } catch (err) {
+        reject(err);
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+export function createFakeOpencodeServer() {
+  const requests = [];
+  const sessions = new Map();
+  let counter = 0;
+  const nextId = (prefix) => `${prefix}_${++counter}`;
+
+  function makeSession(parentID) {
+    const id = nextId("ses");
+    const session = {
+      id,
+      projectID: "test-project",
+      directory: "/tmp/fake-opencode",
+      parentID,
+      title: "fake session",
+      version: "0.0.0-test",
+      time: { created: Date.now(), updated: Date.now() },
+      messages: [],
+      status: { type: "idle" },
+      scenario: undefined,
+      step: 0,
+    };
+    sessions.set(id, session);
+    return session;
+  }
+
+  function assistantMessage(sessionId, text, overrides = {}) {
+    const msgId = nextId("msg");
+    return {
+      info: {
+        id: msgId,
+        sessionID: sessionId,
+        role: "assistant",
+        time: { created: Date.now(), completed: Date.now() },
+        parentID: "",
+        modelID: "fake-model",
+        providerID: "fake",
+        mode: "build",
+        path: { cwd: "/tmp", root: "/tmp" },
+        cost: overrides.cost ?? 0.0001,
+        tokens: overrides.tokens ?? { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
+        finish: "stop",
+        ...(overrides.error ? { error: overrides.error } : {}),
+      },
+      parts: [{ id: nextId("prt"), sessionID: sessionId, messageID: msgId, type: "text", text }],
+    };
+  }
+
+  function toolOnlyAssistantMessage(sessionId, toolName, input, overrides = {}) {
+    const msgId = nextId("msg");
+    return {
+      info: {
+        id: msgId,
+        sessionID: sessionId,
+        role: "assistant",
+        time: { created: Date.now(), completed: Date.now() },
+        parentID: "",
+        modelID: "fake-model",
+        providerID: "fake",
+        mode: "build",
+        path: { cwd: "/tmp", root: "/tmp" },
+        cost: overrides.cost ?? 0.00005,
+        tokens: overrides.tokens ?? { input: 5, output: 2, reasoning: 0, cache: { read: 0, write: 0 } },
+        finish: "tool-calls",
+      },
+      parts: [
+        {
+          id: nextId("prt"),
+          sessionID: sessionId,
+          messageID: msgId,
+          type: "tool",
+          callID: nextId("call"),
+          tool: toolName,
+          state: {
+            status: "completed",
+            input,
+            output: "ok",
+            title: toolName,
+            metadata: {},
+            time: { start: Date.now(), end: Date.now() },
+          },
+        },
+      ],
+    };
+  }
+
+  function taskNotification(sessionId, text) {
+    const msgId = nextId("msg");
+    return {
+      info: {
+        id: msgId,
+        sessionID: sessionId,
+        role: "user",
+        time: { created: Date.now() },
+        agent: "build",
+        model: { providerID: "fake", modelID: "fake-model" },
+      },
+      parts: [{ id: nextId("prt"), sessionID: sessionId, messageID: msgId, type: "text", text }],
+    };
+  }
+
+  function triggerDelegation(session) {
+    const child = makeSession(session.id);
+    child.status = { type: "busy" };
+    setTimeout(() => {
+      child.status = { type: "idle" };
+      session.messages.push(taskNotification(session.id, "<task-notification><status>completed</status></task-notification>"));
+    }, DELEGATE_SETTLE_MS);
+  }
+
+  function handlePrompt(session, text, res) {
+    requests.push({ sessionId: session.id, text });
+    // Real opencode records every prompt the client sends (the initial eval
+    // prompt and any "Continue." follow-up) as a role="user" message in
+    // session history — collectOutcome's turn-boundary logic depends on
+    // that to find where the *last* answered turn starts. taskNotification
+    // has the same shape and is reused here for both purposes.
+    session.messages.push(taskNotification(session.id, text));
+
+    if (session.step === 0) {
+      if (text.includes("__FAKE_OPENCODE_ERROR__")) {
+        session.scenario = "error";
+      } else if (text.includes("__FAKE_OPENCODE_HANG__")) {
+        session.scenario = "hang";
+      } else if (text.includes("__FAKE_OPENCODE_DELEGATE_RACE__")) {
+        session.scenario = "delegate-race";
+      } else if (text.includes("__FAKE_OPENCODE_INFINITE_DELEGATE__")) {
+        session.scenario = "infinite-delegate";
+      } else if (text.includes("__FAKE_OPENCODE_DELEGATE_STUB_FOREVER__")) {
+        session.scenario = "delegate-stub-forever";
+      } else if (text.includes("__FAKE_OPENCODE_DELEGATE_STUB__")) {
+        session.scenario = "delegate-stub";
+      } else if (text.startsWith("__FAKE_OPENCODE_ECHO__")) {
+        session.scenario = "echo";
+      } else if (text.includes("__FAKE_OPENCODE_TOOL_ONLY_FINAL__")) {
+        session.scenario = "tool-only-final";
+      } else if (text.includes("__FAKE_OPENCODE_NO_TEXT__")) {
+        session.scenario = "no-text";
+      } else if (text.includes("__FAKE_OPENCODE_SKILL_TOOL__")) {
+        session.scenario = "skill-tool";
+      } else if (/Assertions:\n[\s\S]*?\nModel output:/.test(text)) {
+        session.scenario = "judge";
+      } else {
+        session.scenario = "default";
+      }
+    }
+    session.step += 1;
+
+    switch (session.scenario) {
+      case "error":
+        respondJson(res, 500, { name: "UnknownError", data: { message: "fake opencode error" } });
+        return;
+      case "hang":
+        // Never respond — the client's own AbortSignal.timeout must fire.
+        return;
+      case "echo": {
+        const payload = text.replace("__FAKE_OPENCODE_ECHO__ ", "");
+        const message = assistantMessage(session.id, payload);
+        session.messages.push(message);
+        respondJson(res, 200, message);
+        return;
+      }
+      case "judge": {
+        const match = text.match(/Assertions:\n([\s\S]*?)\nModel output:/);
+        let assertions = [];
+        try {
+          assertions = match ? JSON.parse(match[1]) : [];
+        } catch {
+          assertions = [];
+        }
+        const assertionResults = assertions.map((a) => ({
+          text: a,
+          passed: true,
+          evidence: "fake judge: assumed satisfied",
+        }));
+        const passed = assertionResults.length;
+        const grading = {
+          assertion_results: assertionResults,
+          summary: { passed, failed: 0, total: passed, pass_rate: passed > 0 ? 1 : 0 },
+        };
+        const message = assistantMessage(session.id, JSON.stringify(grading));
+        session.messages.push(message);
+        respondJson(res, 200, message);
+        return;
+      }
+      case "tool-only-final": {
+        // Simulates opencode splitting one turn across two step-messages: the
+        // real answer lands in an earlier message, and the turn's last step
+        // is a text-less tool call (e.g. a trailing todo-list update).
+        const textMessage = assistantMessage(session.id, "Full review text here.");
+        session.messages.push(textMessage);
+        const toolMessage = toolOnlyAssistantMessage(session.id, "todowrite", { todos: [] });
+        session.messages.push(toolMessage);
+        respondJson(res, 200, toolMessage);
+        return;
+      }
+      case "no-text": {
+        // The entire turn is a single tool-only message — genuinely no text
+        // was ever produced.
+        const toolMessage = toolOnlyAssistantMessage(session.id, "bash", { command: "echo hi" });
+        session.messages.push(toolMessage);
+        respondJson(res, 200, toolMessage);
+        return;
+      }
+      case "skill-tool": {
+        const toolMessage = toolOnlyAssistantMessage(session.id, "skill", { name: "quick-review" });
+        session.messages.push(toolMessage);
+        const textMessage = assistantMessage(session.id, "Review complete.");
+        session.messages.push(textMessage);
+        respondJson(res, 200, textMessage);
+        return;
+      }
+      case "delegate-race": {
+        if (session.step === 1) {
+          const message = assistantMessage(session.id, "Delegation running. I'll synthesize when it returns.");
+          session.messages.push(message);
+          triggerDelegation(session);
+          respondJson(res, 200, message);
+        } else {
+          const message = assistantMessage(session.id, "FAKE_OPENCODE_REAL_ANSWER");
+          session.messages.push(message);
+          respondJson(res, 200, message);
+        }
+        return;
+      }
+      case "infinite-delegate": {
+        const message = assistantMessage(session.id, `Delegation running (round ${session.step}).`);
+        session.messages.push(message);
+        triggerDelegation(session);
+        respondJson(res, 200, message);
+        return;
+      }
+      case "delegate-stub": {
+        // Reproduces the real-world failure: the model calls `delegate` but
+        // never reads its result back, instead ending its own turn with a
+        // "waiting" stub — which looks structurally like a normal final
+        // reply (role "assistant") even though nothing was ever read back.
+        if (session.step === 1) {
+          const toolMessage = toolOnlyAssistantMessage(session.id, "delegate", { prompt: "explore", agent: "explore" });
+          session.messages.push(toolMessage);
+          const stubMessage = assistantMessage(session.id, "Waiting for delegation result...");
+          session.messages.push(stubMessage);
+          respondJson(res, 200, stubMessage);
+        } else {
+          const readMessage = toolOnlyAssistantMessage(session.id, "delegation_read", { id: "fake-delegation-id" });
+          session.messages.push(readMessage);
+          const finalMessage = assistantMessage(session.id, "FAKE_OPENCODE_REAL_ANSWER_AFTER_READ");
+          session.messages.push(finalMessage);
+          respondJson(res, 200, finalMessage);
+        }
+        return;
+      }
+      case "delegate-stub-forever": {
+        // Like "delegate-stub", but never reads its own delegation back on
+        // any continuation — should exhaust maxContinuations and give up
+        // with a diagnostic distinct from the "unanswered notification" case.
+        const toolMessage = toolOnlyAssistantMessage(session.id, "delegate", { prompt: "explore", agent: "explore" });
+        session.messages.push(toolMessage);
+        const stubMessage = assistantMessage(session.id, `Waiting for delegation result... (round ${session.step})`);
+        session.messages.push(stubMessage);
+        respondJson(res, 200, stubMessage);
+        return;
+      }
+      default: {
+        const message = assistantMessage(session.id, "FAKE_OPENCODE_OK");
+        session.messages.push(message);
+        respondJson(res, 200, message);
+      }
+    }
+  }
+
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url, "http://127.0.0.1");
+    try {
+      if (req.method === "POST" && url.pathname === "/session") {
+        const session = makeSession(undefined);
+        respondJson(res, 200, session);
+        return;
+      }
+
+      const messageMatch = url.pathname.match(/^\/session\/([^/]+)\/message$/);
+      if (req.method === "POST" && messageMatch) {
+        const session = sessions.get(messageMatch[1]);
+        if (!session) return respondJson(res, 404, { name: "UnknownError", data: { message: "no such session" } });
+        const body = await readJsonBody(req);
+        const text = body?.parts?.find((p) => p.type === "text")?.text ?? "";
+        handlePrompt(session, text, res);
+        return;
+      }
+
+      if (req.method === "GET" && messageMatch) {
+        const session = sessions.get(messageMatch[1]);
+        if (!session) return respondJson(res, 404, { name: "UnknownError", data: { message: "no such session" } });
+        respondJson(res, 200, session.messages);
+        return;
+      }
+
+      const childrenMatch = url.pathname.match(/^\/session\/([^/]+)\/children$/);
+      if (req.method === "GET" && childrenMatch) {
+        const children = [...sessions.values()].filter((s) => s.parentID === childrenMatch[1]);
+        respondJson(res, 200, children);
+        return;
+      }
+
+      if (req.method === "GET" && url.pathname === "/session/status") {
+        const statusById = {};
+        for (const session of sessions.values()) statusById[session.id] = session.status;
+        respondJson(res, 200, statusById);
+        return;
+      }
+
+      respondJson(res, 404, { name: "UnknownError", data: { message: `no fake route for ${req.method} ${url.pathname}` } });
+    } catch (err) {
+      respondJson(res, 500, { name: "UnknownError", data: { message: err instanceof Error ? err.message : String(err) } });
+    }
+  });
+
+  const sockets = new Set();
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      resolve({
+        url: `http://127.0.0.1:${address.port}`,
+        requests,
+        sessions,
+        close: () =>
+          new Promise((done) => {
+            for (const socket of sockets) socket.destroy();
+            server.close(done);
+          }),
+      });
+    });
+  });
+}

--- a/test/opencode-provider.test.mjs
+++ b/test/opencode-provider.test.mjs
@@ -1,0 +1,266 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { chmodSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { OpencodeProvider } from "../dist/index.js";
+import { createFakeOpencodeServer } from "./fixtures/fake-opencode-server.mjs";
+
+function provider(baseUrl, options = {}) {
+  return new OpencodeProvider({ model: "fake/model", baseUrl, ...options });
+}
+
+test("OpencodeProvider capabilities are all false", () => {
+  const p = provider("http://127.0.0.1:0");
+  assert.deepEqual(p.capabilities, { systemRole: false, attachments: false, toolCalls: false });
+});
+
+test("OpencodeProvider constructor throws when model is missing", () => {
+  assert.throws(() => new OpencodeProvider({ baseUrl: "http://127.0.0.1:0" }), /requires "model"/);
+  assert.throws(() => new OpencodeProvider({ model: "", baseUrl: "http://127.0.0.1:0" }), /requires "model"/);
+});
+
+test("OpencodeProvider.complete: success path returns the assistant's text and usage", async () => {
+  const server = await createFakeOpencodeServer();
+  try {
+    const p = provider(server.url);
+    const result = await p.complete("hello world");
+    assert.equal(result.error, undefined);
+    assert.equal(result.output, "FAKE_OPENCODE_OK");
+    assert.equal(result.inputTokens, 10);
+    assert.equal(result.outputTokens, 5);
+    assert.equal(result.costUsd, 0.0001);
+    assert.equal(result.provider, "opencode");
+    assert.equal(result.model, "fake/model");
+  } finally {
+    await server.close();
+  }
+});
+
+test("OpencodeProvider.complete: talking to an already-running server (baseUrl) attaches no server log — nothing was spawned", async () => {
+  const server = await createFakeOpencodeServer();
+  try {
+    const p = provider(server.url);
+    const result = await p.complete("hello world");
+    assert.equal(result.outputFiles, undefined);
+  } finally {
+    await server.close();
+  }
+});
+
+test("OpencodeProvider.complete: when it spawns its own opencode server, captures the full stdout+stderr log — including everything logged after startup", async () => {
+  const binDir = mkdtempSync(path.join(tmpdir(), "opencode-bin-"));
+  const fakeBinaryPath = path.resolve("test/fixtures/fake-opencode-binary.mjs");
+  const wrapperPath = path.join(binDir, "opencode");
+  writeFileSync(wrapperPath, `#!/bin/sh\nexec node ${JSON.stringify(fakeBinaryPath)} "$@"\n`);
+  chmodSync(wrapperPath, 0o755);
+
+  const originalPath = process.env.PATH;
+  process.env.PATH = `${binDir}:${originalPath}`;
+  try {
+    const p = new OpencodeProvider({ model: "fake/model", timeoutMs: 10_000 });
+    // Uses the delegate-race scenario (~300ms of polling before it resolves,
+    // see the fixture) so the run outlasts the fake binary's 50ms
+    // post-startup log write — proving capture isn't cut off at "settled"
+    // the way a fast-resolving prompt wouldn't reliably exercise.
+    const result = await p.complete("__FAKE_OPENCODE_DELEGATE_RACE__");
+    assert.equal(result.error, undefined);
+    assert.equal(result.output, "FAKE_OPENCODE_REAL_ANSWER");
+    const log = result.outputFiles?.find((f) => f.path === "opencode-serve.log");
+    assert.ok(log, "expected an opencode-serve.log output file");
+    assert.match(log.content, /opencode server listening on/);
+    assert.match(log.content, /post-startup stdout line/);
+    assert.match(log.content, /post-startup stderr line/);
+  } finally {
+    process.env.PATH = originalPath;
+  }
+});
+
+test("OpencodeProvider.complete: server error resolves with error set, does not throw", async () => {
+  const server = await createFakeOpencodeServer();
+  try {
+    const p = provider(server.url);
+    const result = await p.complete("__FAKE_OPENCODE_ERROR__");
+    assert.equal(result.output, "");
+    assert.match(result.error, /fake opencode error/);
+  } finally {
+    await server.close();
+  }
+});
+
+test("OpencodeProvider.complete: a hung prompt call resolves with a timeout error instead of hanging", async () => {
+  const server = await createFakeOpencodeServer();
+  try {
+    const p = provider(server.url, { timeoutMs: 300 });
+    const started = Date.now();
+    const result = await p.complete("__FAKE_OPENCODE_HANG__");
+    const elapsed = Date.now() - started;
+    assert.match(result.error, /timed out|abort/i);
+    assert.ok(elapsed < 5000, `expected timeout to fire quickly, took ${elapsed}ms`);
+  } finally {
+    await server.close();
+  }
+});
+
+test("OpencodeProvider.complete: a subagent's async delegation does not truncate the run — waits for the real final answer", async () => {
+  const server = await createFakeOpencodeServer();
+  try {
+    const p = provider(server.url, { timeoutMs: 10_000, maxContinuations: 3 });
+    const started = Date.now();
+    const result = await p.complete("__FAKE_OPENCODE_DELEGATE_RACE__");
+    const elapsed = Date.now() - started;
+    assert.equal(result.error, undefined);
+    assert.equal(result.output, "FAKE_OPENCODE_REAL_ANSWER");
+    assert.ok(elapsed >= 250, `expected to wait for the delegated child to settle, took ${elapsed}ms`);
+    assert.ok(elapsed < 8000, `expected a fast, bounded run, took ${elapsed}ms`);
+  } finally {
+    await server.close();
+  }
+});
+
+test("OpencodeProvider.complete: gives up after maxContinuations instead of looping forever on repeated re-delegation", async () => {
+  const server = await createFakeOpencodeServer();
+  try {
+    const p = provider(server.url, { timeoutMs: 10_000, maxContinuations: 2 });
+    const result = await p.complete("__FAKE_OPENCODE_INFINITE_DELEGATE__");
+    assert.match(result.error, /gave up after 2 follow-up/);
+    // The give-up path shouldn't discard text a prior, already-answered
+    // round actually produced just because the run ultimately errored.
+    assert.match(result.output, /Delegation running/);
+  } finally {
+    await server.close();
+  }
+});
+
+test("OpencodeProvider.complete: a premature 'waiting on delegation' stub reply is not accepted as final — the harness keeps going until the model reads its result back", async () => {
+  const server = await createFakeOpencodeServer();
+  try {
+    const p = provider(server.url, { timeoutMs: 10_000, maxContinuations: 3 });
+    const result = await p.complete("__FAKE_OPENCODE_DELEGATE_STUB__");
+    assert.equal(result.error, undefined);
+    assert.equal(result.output, "FAKE_OPENCODE_REAL_ANSWER_AFTER_READ");
+    assert.ok(result.toolCalls?.some((c) => c.function.name === "delegation_read"));
+  } finally {
+    await server.close();
+  }
+});
+
+test("OpencodeProvider.complete: gives up with a distinct diagnostic when the model never reads back its own dispatched delegation", async () => {
+  const server = await createFakeOpencodeServer();
+  try {
+    const p = provider(server.url, { timeoutMs: 10_000, maxContinuations: 2 });
+    const result = await p.complete("__FAKE_OPENCODE_DELEGATE_STUB_FOREVER__");
+    assert.match(result.error, /gave up after 2 follow-up prompt\(s\) waiting for the model to read back a dispatched delegation's result/);
+  } finally {
+    await server.close();
+  }
+});
+
+test("OpencodeProvider.complete: recovers text from an earlier step-message even when the turn's final message is tool-only", async () => {
+  const server = await createFakeOpencodeServer();
+  try {
+    const p = provider(server.url);
+    const result = await p.complete("__FAKE_OPENCODE_TOOL_ONLY_FINAL__");
+    assert.equal(result.error, undefined);
+    assert.equal(result.output, "Full review text here.");
+    assert.ok(result.toolCalls?.some((c) => c.function.name === "todowrite"));
+  } finally {
+    await server.close();
+  }
+});
+
+test("OpencodeProvider.complete: a turn with no text anywhere surfaces a diagnostic error instead of a silent empty success", async () => {
+  const server = await createFakeOpencodeServer();
+  try {
+    const p = provider(server.url);
+    const result = await p.complete("__FAKE_OPENCODE_NO_TEXT__");
+    assert.equal(result.output, "");
+    assert.match(result.error, /produced no text output/);
+  } finally {
+    await server.close();
+  }
+});
+
+test("OpencodeProvider.complete: captures tool calls, including a skill invocation with its parsed arguments", async () => {
+  const server = await createFakeOpencodeServer();
+  try {
+    const p = provider(server.url);
+    const result = await p.complete("__FAKE_OPENCODE_SKILL_TOOL__");
+    assert.equal(result.error, undefined);
+    assert.equal(result.output, "Review complete.");
+    const skillCall = result.toolCalls?.find((c) => c.function.name === "skill");
+    assert.ok(skillCall, "expected a skill tool call to be captured");
+    assert.equal(skillCall.parsedArguments.name, "quick-review");
+  } finally {
+    await server.close();
+  }
+});
+
+test("OpencodeProvider.complete: sends agent/model in the request body", async () => {
+  const server = await createFakeOpencodeServer();
+  try {
+    const p = provider(server.url, { agent: "build", model: "tensorix/minimax/minimax-m3" });
+    await p.complete("hello world");
+    assert.equal(server.requests.length, 1);
+    assert.equal(server.requests[0].text, "hello world");
+  } finally {
+    await server.close();
+  }
+});
+
+test("OpencodeProvider.complete: prompt round-trips without mangling special characters", async () => {
+  const server = await createFakeOpencodeServer();
+  try {
+    const p = provider(server.url);
+    const payload = 'some `$(echo injected)` "quoted" text\nwith a newline';
+    const result = await p.complete(`__FAKE_OPENCODE_ECHO__ ${payload}`);
+    assert.equal(result.output, payload);
+  } finally {
+    await server.close();
+  }
+});
+
+function makeFakeSkill() {
+  const skillDir = mkdtempSync(path.join(tmpdir(), "opencode-skill-"));
+  writeFileSync(path.join(skillDir, "SKILL.md"), "---\nname: my-skill\ndescription: test\n---\nbody");
+  mkdirSync(path.join(skillDir, "references"));
+  writeFileSync(path.join(skillDir, "references", "notes.md"), "notes");
+  mkdirSync(path.join(skillDir, "scripts"));
+  writeFileSync(path.join(skillDir, "scripts", "helper.sh"), "#!/bin/sh\necho hi");
+  writeFileSync(path.join(skillDir, "LICENSE"), "MIT");
+  mkdirSync(path.join(skillDir, "evals"));
+  writeFileSync(path.join(skillDir, "evals", "evals.json"), '{"evals":[]}');
+  return { name: "my-skill", dir: skillDir };
+}
+
+test("OpencodeProvider.prepareSkill: with_skill symlinks every skill-dir entry except evals/", async () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "opencode-dir-"));
+  const p = provider("http://127.0.0.1:0", { dir });
+  const skill = makeFakeSkill();
+  const installDir = path.join(dir, ".opencode", "skills", "my-skill");
+
+  await p.prepareSkill(skill, "with_skill");
+
+  assert.ok(lstatSync(path.join(installDir, "SKILL.md")).isSymbolicLink());
+  assert.equal(readlinkSync(path.join(installDir, "SKILL.md")), path.join(skill.dir, "SKILL.md"));
+  assert.ok(lstatSync(path.join(installDir, "references")).isSymbolicLink());
+  assert.ok(lstatSync(path.join(installDir, "scripts")).isSymbolicLink());
+  assert.ok(lstatSync(path.join(installDir, "LICENSE")).isSymbolicLink());
+  assert.equal(existsSync(path.join(installDir, "evals")), false);
+
+  await p.cleanupSkill(skill, "with_skill");
+  assert.equal(existsSync(installDir), false);
+});
+
+test("OpencodeProvider.prepareSkill: without_skill installs nothing and removes any prior install", async () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "opencode-dir-"));
+  const p = provider("http://127.0.0.1:0", { dir });
+  const skill = makeFakeSkill();
+  const installDir = path.join(dir, ".opencode", "skills", "my-skill");
+
+  await p.prepareSkill(skill, "with_skill");
+  assert.ok(existsSync(installDir));
+
+  await p.prepareSkill(skill, "without_skill");
+  assert.equal(existsSync(installDir), false);
+});


### PR DESCRIPTION
## Summary

- Add `--run-mode opencode`: route target/judge calls through a real opencode CLI session (via @opencode-ai/sdk) instead of an OpenAI-compatible HTTP API, so agentic skills that shell out (git, bash, file edits) can be evaluated with real tool access rather than a single chat completion. 
- Extend Provider with optional `prepareSkill`/`cleanupSkill` so providers that natively discover skills on disk can symlink/unlink them into <opencode.dir>/.opencode/skills/<name>/ per run instead of injecting the skill into the prompt 
- Report and eval-run code (src/report.ts, src/evaluate-skills.ts) surface a "skill picked up" badge and warn once when tool_assertions are used against a provider that can't map to them.
- Add examples/quick-review, a fully agentic example skill (with a fixture-repo git checkout built by setup_fixture.py) plus examples/agent-skills-eval.quick-review.yaml and scripts/run-quick-review-eval.sh as an end-to-end demo/fixture
- Add unit/integration tests covering opencode run-mode CLI validation and provider behavior against a fake opencode server.

## Validation

- [x] npm test
- [x] npm pack --dry-run

## Notes

- `--opencode-auto` auto-approves opencode's own bash/file-edit permission prompts for the run's duration — off by default, called out explicitly in the README as dangerous for unattended use.
- `opencode-mode` token/cost figures aren't apples-to-apples with API mode (opencode's own system prompt/tool schemas add fixed overhead per call).